### PR TITLE
수거함 리뷰 등록 기능 구현

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepositoryImpl.java
@@ -37,6 +37,7 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
                 .from(review)
                 .where(review.collectingBox.id.eq(id))
                 .orderBy(review.createdAt.desc())
+                .limit(10)
                 .fetch();
 
         response.setReviews(reviews);

--- a/src/main/java/contest/collectingbox/module/review/application/ReviewService.java
+++ b/src/main/java/contest/collectingbox/module/review/application/ReviewService.java
@@ -1,0 +1,23 @@
+package contest.collectingbox.module.review.application;
+
+import contest.collectingbox.module.collectingbox.domain.CollectingBox;
+import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
+import contest.collectingbox.module.review.domain.ReviewRepository;
+import contest.collectingbox.module.review.dto.ReviewRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final CollectingBoxRepository collectingBoxRepository;
+
+    public Long postReview(ReviewRequest dto, Long collectionId) {
+        CollectingBox box = collectingBoxRepository.findById(collectionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 수거함이 없습니다."));
+        return reviewRepository.save(dto.toEntity(box)).getId();
+    }
+}

--- a/src/main/java/contest/collectingbox/module/review/domain/Review.java
+++ b/src/main/java/contest/collectingbox/module/review/domain/Review.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,4 +33,10 @@ public class Review extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Tag tag;
+
+    @Builder
+    public Review(CollectingBox collectingBox, Tag tag) {
+        this.collectingBox = collectingBox;
+        this.tag = tag;
+    }
 }

--- a/src/main/java/contest/collectingbox/module/review/dto/ReviewRequest.java
+++ b/src/main/java/contest/collectingbox/module/review/dto/ReviewRequest.java
@@ -1,0 +1,21 @@
+package contest.collectingbox.module.review.dto;
+
+import contest.collectingbox.module.collectingbox.domain.CollectingBox;
+import contest.collectingbox.module.review.domain.Review;
+import contest.collectingbox.module.review.domain.Tag;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class ReviewRequest {
+    private String content;
+
+    public Review toEntity(CollectingBox collectingBox) {
+        return Review.builder().
+                collectingBox(collectingBox)
+                .tag(Tag.valueOf(content))
+                .build();
+    }
+}

--- a/src/main/java/contest/collectingbox/module/review/dto/ReviewResponse.java
+++ b/src/main/java/contest/collectingbox/module/review/dto/ReviewResponse.java
@@ -3,19 +3,18 @@ package contest.collectingbox.module.review.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class ReviewResponse {
-    private String status;
+    private String content;
     private String createdDate;
 
     @QueryProjection
-    public ReviewResponse(String status, String createdDate) {
-        this.status = status;
+    public ReviewResponse(String content, String createdDate) {
+        this.content = content;
         this.createdDate = formatDate(createdDate);
     }
 

--- a/src/main/java/contest/collectingbox/module/review/presentation/ReviewController.java
+++ b/src/main/java/contest/collectingbox/module/review/presentation/ReviewController.java
@@ -1,0 +1,26 @@
+package contest.collectingbox.module.review.presentation;
+
+import contest.collectingbox.global.common.ApiResponse;
+import contest.collectingbox.module.review.application.ReviewService;
+import contest.collectingbox.module.review.dto.ReviewRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/collections")
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    @PostMapping("/{collectionId}/review")
+    public ApiResponse<Long> postReview(@RequestBody ReviewRequest dto, @PathVariable Long collectionId) {
+        log.info("collectionID for post review = {}", collectionId);
+        return ApiResponse.ok(reviewService.postReview(dto, collectionId));
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] 수거함 리뷰 등록 기능 구현


## 💡 자세한 설명
리뷰 등록 기능을 구현했습니다. 
존재하지 않는 수거함 id로 리뷰 등록 시도 시 예외 발생 처리를 하였는데 이는 추후 개선 예정입니다. 
리뷰의 내용을 응답과 요청 데이터 모두 "content"로 통일했습니다. 

## 🚩 후속 작업 
- 단위 테스트 코드 작성
- 로그 정리 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?

closes #21 
