### PR TITLE
지역별 수거함 검색 기능 개선

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
@@ -17,12 +17,17 @@ public interface CollectingBoxRepository extends JpaRepository<CollectingBox, Lo
                                           @Param("tags") List<Tag> tags);
 
 
-    @Query("select c from CollectingBox c join c.location l " +
-            "where (l.address.sigungu like :keyword or " +
-            "l.address.dong like :keyword or " +
-            "l.address.roadName like :keyword or " +
-            "l.address.streetNum like :keyword) and " +
-            "c.tag in :tags")
+    @Query(value = "select c.* from collecting_box as c " +
+            "join location as l on c.location_id = l.id " +
+            "where match (l.dong) against (:dong in natural language mode) and " +
+            "c.tag in (:tags)", nativeQuery = true)
+    List<CollectingBox> findAllByDong(@Param("dong") String dong,
+                                      @Param("tags") List<String> tags);
+
+    @Query(value = "select c.* from collecting_box as c " +
+            "join location as l on c.location_id = l.id " +
+            "where match(l.sigungu) against (:keyword in natural language mode) and " +
+            "c.tag in (:tags)", nativeQuery = true)
     List<CollectingBox> findAllByKeyword(@Param("keyword") String keyword,
-                                         @Param("tags") List<Tag> tags);
+                                         @Param("tags") List<String> tags);
 }

--- a/src/main/java/contest/collectingbox/module/location/domain/LocationRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/LocationRepository.java
@@ -1,6 +1,12 @@
 package contest.collectingbox.module.location.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
+
+    @Query(value = "select dong from location " +
+            "where match (dong) against (:keyword in natural language mode) limit 1", nativeQuery = true)
+    String findDongByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -9,43 +9,51 @@ DROP TABLE IF EXISTS location;
 DROP TABLE IF EXISTS review;
 
 -- collecting_box 테이블을 생성합니다.
-CREATE TABLE collecting_box (
-                                id BIGINT NOT NULL AUTO_INCREMENT,
-                                location_id BIGINT,
-                                tag ENUM ('CLOTHES','LAMP','BATTERY','MEDICINE','TRASH') NOT NULL,
-                                created_at DATETIME(6),
-                                updated_at DATETIME(6),
-                                PRIMARY KEY (id)
+CREATE TABLE collecting_box
+(
+    id          BIGINT NOT NULL AUTO_INCREMENT,
+    location_id BIGINT,
+    tag         ENUM ('CLOTHES','LAMP','BATTERY','MEDICINE','TRASH') NOT NULL,
+    created_at  DATETIME(6),
+    updated_at  DATETIME(6),
+    PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 
 -- location 테이블을 생성합니다.
-CREATE TABLE location (
-                          id BIGINT NOT NULL AUTO_INCREMENT,
-                          name VARCHAR(255),
-                          point POINT SRID 4326,
-                          sido VARCHAR(255),
-                          sigungu VARCHAR(255),
-                          dong VARCHAR(255),
-                          road_name VARCHAR(255),
-                          street_num VARCHAR(255),
-                          created_at DATETIME(6),
-                          updated_at DATETIME(6),
-                          PRIMARY KEY (id)
+CREATE TABLE location
+(
+    id         BIGINT NOT NULL AUTO_INCREMENT,
+    name       VARCHAR(255),
+    point      POINT SRID 4326,
+    sido       VARCHAR(255),
+    sigungu    VARCHAR(255),
+    dong       VARCHAR(255),
+    road_name  VARCHAR(255),
+    street_num VARCHAR(255),
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    FULLTEXT INDEX ft_sigungu_idx (sigungu) WITH PARSER ngram,
+    FULLTEXT INDEX ft_dong_idx (dong) WITH PARSER ngram,
+    PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 
 -- review 테이블을 생성합니다.
-CREATE TABLE review (
-                        id BIGINT NOT NULL AUTO_INCREMENT,
-                        collecting_box_id BIGINT,
-                        tag ENUM ('EXIST','DISAPPEAR') NOT NULL,
-                        created_at DATETIME(6),
-                        updated_at DATETIME(6),
-                        PRIMARY KEY (id)
+CREATE TABLE review
+(
+    id                BIGINT NOT NULL AUTO_INCREMENT,
+    collecting_box_id BIGINT,
+    tag               ENUM ('EXIST','DISAPPEAR') NOT NULL,
+    created_at        DATETIME(6),
+    updated_at        DATETIME(6),
+    PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 
 -- collecting_box 테이블에 location_id에 대한 유니크 제약 조건과 외래 키 제약 조건을 추가합니다.
-ALTER TABLE collecting_box ADD CONSTRAINT UK_bkm6f6gxm52ixb4yl2k6ef900 UNIQUE (location_id);
-ALTER TABLE collecting_box ADD CONSTRAINT FKsuc8jedi2qm3kwaw3ptm1jiw3 FOREIGN KEY (location_id) REFERENCES location (id);
+ALTER TABLE collecting_box
+    ADD CONSTRAINT UK_bkm6f6gxm52ixb4yl2k6ef900 UNIQUE (location_id);
+ALTER TABLE collecting_box
+    ADD CONSTRAINT FKsuc8jedi2qm3kwaw3ptm1jiw3 FOREIGN KEY (location_id) REFERENCES location (id);
 
 -- review 테이블에 collecting_box_id에 대한 외래 키 제약 조건을 추가합니다.
-ALTER TABLE review ADD CONSTRAINT FKdituvqscjan1gv6o3fpx1duay FOREIGN KEY (collecting_box_id) REFERENCES collecting_box (id);
+ALTER TABLE review
+    ADD CONSTRAINT FKdituvqscjan1gv6o3fpx1duay FOREIGN KEY (collecting_box_id) REFERENCES collecting_box (id);


### PR DESCRIPTION
## 💡 작업 내용
- [x] schema.sql 내 SQL문 정렬
- [x] schema.sql 내 테이블 생성 시 FullText index 추가
- [x] 지역별 수거함 검색 기능 개선

## 💡 자세한 설명
기존 LIKE 키워드를 활용한 검색 API의 경우 index 생성이 불가능하여 성능이 떨어지는 문제가 있었습니다.
따라서 MySQL에서 제공하는 FullText index를 활용해 해당 로직을 개선했습니다.

## 📗 참고 자료
[MySQL FullText Search, 제대로 이해하기](https://gngsn.tistory.com/162#google_vignette)

[MySQL :: MySQL 8.3 Reference Manual :: 14.9 Full-Text Search Functions](https://dev.mysql.com/doc/refman/8.3/en/fulltext-search.html)
## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #25 
