### PR TITLE
수거함 목록 조회 기능 예외 처리

### DIFF
--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public enum ErrorCode {
     // 400
     NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
-    MISSING_REQUEST_PARAM(BAD_REQUEST, "요청된 쿼리 파라미터가 존재하지 않습니다.");
+    MISSING_REQUEST_PARAM(BAD_REQUEST, "요청된 쿼리 파라미터가 존재하지 않습니다."),
+    MISMATCH_REQUEST_PARAM(BAD_REQUEST, "요청된 쿼리 파라미터의 타입이 유효하지 않습니다.");
 
     // 404
 

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -10,7 +10,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @AllArgsConstructor
 public enum ErrorCode {
     // 400
-    NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다.");
+    NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
+    MISSING_REQUEST_PARAM(BAD_REQUEST, "요청된 쿼리 파라미터가 존재하지 않습니다.");
 
     // 404
 

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -11,8 +11,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public enum ErrorCode {
     // 400
     NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
-    MISSING_REQUEST_PARAM(BAD_REQUEST, "요청된 쿼리 파라미터가 존재하지 않습니다."),
-    MISMATCH_REQUEST_PARAM(BAD_REQUEST, "요청된 쿼리 파라미터의 타입이 유효하지 않습니다.");
+    MISSING_REQUEST_PARAM(BAD_REQUEST, "필수 요청 파라미터가 존재하지 않습니다."),
+    MISMATCH_REQUEST_PARAM(BAD_REQUEST, "요청 파라미터가 유효하지 않습니다.");
 
     // 404
 

--- a/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
@@ -2,8 +2,13 @@ package contest.collectingbox.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static contest.collectingbox.global.exception.ErrorCode.MISSING_REQUEST_PARAM;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Slf4j
 @RestControllerAdvice
@@ -11,8 +16,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CollectingBoxException.class)
     public ResponseEntity<ErrorResponse> handleCollectingBoxException(CollectingBoxException e) {
-        ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
         log.error("exception message = {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
         return ResponseEntity.status(errorResponse.getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ErrorResponse handleMissingParams(MissingServletRequestParameterException e) {
+        log.error("exception message = {}", e.getMessage());
+        return ErrorResponse.from(MISSING_REQUEST_PARAM);
     }
 }

--- a/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
@@ -6,7 +6,9 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import static contest.collectingbox.global.exception.ErrorCode.MISMATCH_REQUEST_PARAM;
 import static contest.collectingbox.global.exception.ErrorCode.MISSING_REQUEST_PARAM;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
@@ -26,5 +28,12 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleMissingParams(MissingServletRequestParameterException e) {
         log.error("exception message = {}", e.getMessage());
         return ErrorResponse.from(MISSING_REQUEST_PARAM);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ErrorResponse handleMissingParams(MethodArgumentTypeMismatchException e) {
+        log.error("exception message = {}", e.getMessage());
+        return ErrorResponse.from(MISMATCH_REQUEST_PARAM);
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -1,5 +1,7 @@
 package contest.collectingbox.module.collectingbox.application;
 
+import contest.collectingbox.global.exception.CollectingBoxException;
+import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
@@ -29,6 +31,10 @@ public class CollectingBoxService {
     public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final Double latitude,
                                                                      final Double longitude,
                                                                      final List<Tag> tags) {
+        if (tags.isEmpty()) {
+            throw new CollectingBoxException(ErrorCode.NOT_SELECTED_TAG);
+        }
+
         Point center = GeometryUtil.toPoint(longitude, latitude);
 
         return collectingBoxRepository.findAllWithinArea(center, radius, tags)

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -26,9 +26,9 @@ public class CollectingBoxService {
     private int radius;
 
     @Transactional(readOnly = true)
-    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(Double latitude,
-                                                                     Double longitude,
-                                                                     List<Tag> tags) {
+    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final Double latitude,
+                                                                     final Double longitude,
+                                                                     final List<Tag> tags) {
         Point center = GeometryUtil.toPoint(longitude, latitude);
 
         return collectingBoxRepository.findAllWithinArea(center, radius, tags)

--- a/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
@@ -21,13 +21,10 @@ public class CollectingBoxController {
     private final CollectingBoxService collectingBoxService;
 
     @Operation(summary = "수거함 목록 조회", description = "위도와 경도를 기준으로 200m 반경에 위치한 수거함 목록을 조회합니다.")
-    @ApiResponses(value = {
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "BAD_REQUEST")
-    })
     @GetMapping
-    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam Double latitude,
-                                                                                  @RequestParam Double longitude,
-                                                                                  @RequestParam List<Tag> tags) {
+    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam final Double latitude,
+                                                                                  @RequestParam final Double longitude,
+                                                                                  @RequestParam final List<Tag> tags) {
         return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(latitude, longitude, tags));
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 파라미터에 final 키워드 추가
- [x] 요청 쿼리 파라미터 누락에 대한 예외 처리
- [x] 요청 쿼리 파라미터가 유효하지 않을 때에 대한 예외 처리
- [x] 태그 미선택에 대한 예외 처리

## 💡 자세한 설명
수거함 목록 조회 기능에서 발생 가능한 예외를 처리하는 로직을 구현했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #36 
