### PR TITLE
지역별 수거함 검색 기능 예외 처리

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -43,21 +43,23 @@ public class CollectingBoxService {
     }
 
     @Transactional(readOnly = true)
-    public List<CollectingBoxResponse> searchCollectingBoxes(String query, List<Tag> tags) {
-        List<String> tagStrings = tags.stream().map(Enum::name).collect(Collectors.toList());
-
+    public List<CollectingBoxResponse> searchCollectingBoxes(final String query, final List<Tag> tags) {
         String dong = locationRepository.findDongByKeyword(query);
 
         if (dong == null) {
-            return collectingBoxRepository.findAllByKeyword(query, tagStrings)
+            return collectingBoxRepository.findAllByKeyword(query, toString(tags))
                     .stream()
                     .map(CollectingBoxResponse::fromEntity)
                     .collect(Collectors.toList());
         }
 
-        return collectingBoxRepository.findAllByDong(dong, tagStrings)
+        return collectingBoxRepository.findAllByDong(dong, toString(tags))
                 .stream()
                 .map(CollectingBoxResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    private List<String> toString(List<Tag> tags) {
+        return tags.stream().map(Enum::name).collect(Collectors.toList());
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -47,7 +47,7 @@ public class CollectingBoxService {
         String dong = locationRepository.findDongByKeyword(query);
 
         if (dong == null) {
-            return collectingBoxRepository.findAllByKeyword(query, toString(tags))
+            return collectingBoxRepository.findAllBySigungu(query, toString(tags))
                     .stream()
                     .map(CollectingBoxResponse::fromEntity)
                     .collect(Collectors.toList());

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -1,5 +1,7 @@
 package contest.collectingbox.module.collectingbox.application;
 
+import contest.collectingbox.global.exception.CollectingBoxException;
+import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
@@ -44,6 +46,10 @@ public class CollectingBoxService {
 
     @Transactional(readOnly = true)
     public List<CollectingBoxResponse> searchCollectingBoxes(final String query, final List<Tag> tags) {
+        if (tags.isEmpty()) {
+            throw new CollectingBoxException(ErrorCode.NOT_SELECTED_TAG);
+        }
+
         String dong = locationRepository.findDongByKeyword(query);
 
         if (dong == null) {

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
@@ -26,8 +26,8 @@ public interface CollectingBoxRepository extends JpaRepository<CollectingBox, Lo
 
     @Query(value = "select c.* from collecting_box as c " +
             "join location as l on c.location_id = l.id " +
-            "where match(l.sigungu) against (:keyword in natural language mode) and " +
+            "where match(l.sigungu) against (:sigungu in natural language mode) and " +
             "c.tag in (:tags)", nativeQuery = true)
-    List<CollectingBox> findAllByKeyword(@Param("keyword") String keyword,
+    List<CollectingBox> findAllBySigungu(@Param("sigungu") String sigungu,
                                          @Param("tags") List<String> tags);
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
@@ -33,8 +33,8 @@ public class CollectingBoxController {
 
     @Operation(summary = "지역별 수거함 검색", description = "구/동 단위로 검색한 주소에 위치한 수거함 목록을 조회합니다.")
     @GetMapping("/search")
-    public ApiResponse<List<CollectingBoxResponse>> searchCollectingBoxes(@RequestParam String query,
-                                                                          @RequestParam List<Tag> tags) {
+    public ApiResponse<List<CollectingBoxResponse>> searchCollectingBoxes(@RequestParam final String query,
+                                                                          @RequestParam final List<Tag> tags) {
         return ApiResponse.ok(collectingBoxService.searchCollectingBoxes(query, tags));
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 수거함 태그 미선택에 대한 예외 처리
- [x] 메서드 및 파라미터 이름 개선
- [x] 변경되지 않아야 할 파라미터에 final 키워드 추가

## 💡 자세한 설명
지역별 수거함 검색 기능에서 발생 가능한 예외를 처리하는 로직을 구현했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #38 
