### PR TITLE
수거함 상세보기 조회 기능 예외처리

### DIFF
--- a/src/main/java/contest/collectingbox/global/common/CommonUtils.java
+++ b/src/main/java/contest/collectingbox/global/common/CommonUtils.java
@@ -1,0 +1,12 @@
+package contest.collectingbox.global.common;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class CommonUtils {
+    public static String formatDate(String inputDate) {
+        LocalDateTime dateTime = LocalDateTime.parse(inputDate,
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSS"));
+        return dateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"));
+    }
+}

--- a/src/main/java/contest/collectingbox/global/common/CommonUtils.java
+++ b/src/main/java/contest/collectingbox/global/common/CommonUtils.java
@@ -1,12 +1,23 @@
 package contest.collectingbox.global.common;
 
+import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
+
+import contest.collectingbox.global.exception.CollectingBoxException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class CommonUtils {
     public static String formatDate(String inputDate) {
-        LocalDateTime dateTime = LocalDateTime.parse(inputDate,
-                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSS"));
-        return dateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"));
+        try{
+            LocalDateTime dateTime = LocalDateTime.parse(inputDate,
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
+            return dateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"));
+        }catch(DateTimeParseException e){
+            log.error("exception message = {}", e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/contest/collectingbox/global/common/DateUtils.java
+++ b/src/main/java/contest/collectingbox/global/common/DateUtils.java
@@ -1,15 +1,14 @@
 package contest.collectingbox.global.common;
 
-import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
-
-import contest.collectingbox.global.exception.CollectingBoxException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class CommonUtils {
+@UtilityClass
+public class DateUtils {
     public static String formatDate(String inputDate) {
         try{
             LocalDateTime dateTime = LocalDateTime.parse(inputDate,

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -5,14 +5,16 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
     // 400
-    NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다.");
+    NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
 
     // 404
+    NOT_FOUND_COLLECTING_BOX(NOT_FOUND, "해당 수거함이 존재하지 않습니다.");
 
     // 409
 

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     // 400
     NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
     MISSING_REQUEST_PARAM(BAD_REQUEST, "필수 요청 파라미터가 존재하지 않습니다."),
-    MISMATCH_REQUEST_PARAM(BAD_REQUEST, "요청 파라미터가 유효하지 않습니다.");
+    MISMATCH_REQUEST_PARAM(BAD_REQUEST, "요청 파라미터가 유효하지 않습니다."),
 
     // 404
     NOT_FOUND_COLLECTING_BOX(NOT_FOUND, "해당 수거함이 존재하지 않습니다."),

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -12,10 +12,12 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public enum ErrorCode {
     // 400
     NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
-
+    ILLEGAL_ARGUMENT(BAD_REQUEST, "입력값이 부적절한 인자입니다."),
     // 404
-    NOT_FOUND_COLLECTING_BOX(NOT_FOUND, "해당 수거함이 존재하지 않습니다.");
+    NOT_FOUND_COLLECTING_BOX(NOT_FOUND, "해당 수거함이 존재하지 않습니다."),
 
+    // 임시
+    NOT_FOUND_TAG(NOT_FOUND, "해당 이름과 일치하는 수거함 태그가 없습니다.");
     // 409
 
     // 500

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -12,7 +12,6 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public enum ErrorCode {
     // 400
     NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
-    ILLEGAL_ARGUMENT(BAD_REQUEST, "입력값이 부적절한 인자입니다."),
     // 404
     NOT_FOUND_COLLECTING_BOX(NOT_FOUND, "해당 수거함이 존재하지 않습니다."),
 

--- a/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,12 @@
 package contest.collectingbox.global.exception;
 
+import static contest.collectingbox.global.exception.ErrorCode.ILLEGAL_ARGUMENT;
+
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
@@ -14,5 +18,11 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
         log.error("exception message = {}", e.getMessage());
         return ResponseEntity.status(errorResponse.getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorResponse handleIllegalArgument(IllegalArgumentException e){
+        log.error("exception message = {}", e.getMessage());
+        return ErrorResponse.from(ILLEGAL_ARGUMENT);
     }
 }

--- a/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
@@ -1,12 +1,9 @@
 package contest.collectingbox.global.exception;
 
-import static contest.collectingbox.global.exception.ErrorCode.ILLEGAL_ARGUMENT;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
@@ -18,11 +15,5 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
         log.error("exception message = {}", e.getMessage());
         return ResponseEntity.status(errorResponse.getHttpStatus()).body(errorResponse);
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ErrorResponse handleIllegalArgument(IllegalArgumentException e){
-        log.error("exception message = {}", e.getMessage());
-        return ErrorResponse.from(ILLEGAL_ARGUMENT);
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -1,6 +1,11 @@
 package contest.collectingbox.module.collectingbox.application;
 
+import static contest.collectingbox.global.exception.ErrorCode.*;
+
+import contest.collectingbox.global.exception.CollectingBoxException;
+import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
+import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
@@ -39,7 +44,10 @@ public class CollectingBoxService {
 
     @Transactional(readOnly = true)
     public CollectingBoxDetailResponse findBoxDetailById(Long collectionId) {
-        return collectingBoxRepository.findDetailById(collectionId);
+        CollectingBox box = collectingBoxRepository.findById(collectionId)
+                .orElseThrow(() -> new CollectingBoxException(
+                        NOT_FOUND_COLLECTING_BOX));
+        return collectingBoxRepository.findDetailById(box.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepositoryImpl.java
@@ -25,7 +25,7 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
         CollectingBoxDetailResponse response = queryFactory.select(new QCollectingBoxDetailResponse(
                         location.name, location.address.roadName,
                         location.address.streetNum,
-                        collectingBox.updatedAt.stringValue(), collectingBox.tag.stringValue()
+                        collectingBox.updatedAt.stringValue(), collectingBox.tag
                 ))
                 .from(collectingBox)
                 .join(collectingBox.location, location)

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/Tag.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/Tag.java
@@ -16,11 +16,4 @@ public enum Tag {
 
     private final String label;
 
-    public static String of(final String text) {
-        Tag tag = Arrays.stream(values())
-                .filter(val -> val.name().equals(text))
-                .findFirst()
-                .orElseThrow(IllegalArgumentException::new);
-        return tag.getLabel();
-    }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/Tag.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/Tag.java
@@ -20,7 +20,7 @@ public enum Tag {
         Tag tag = Arrays.stream(values())
                 .filter(val -> val.name().equals(text))
                 .findFirst()
-                .orElse(null);
-        return tag != null ? tag.getLabel() : null;
+                .orElseThrow(IllegalArgumentException::new);
+        return tag.getLabel();
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxDetailResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxDetailResponse.java
@@ -31,12 +31,12 @@ public class CollectingBoxDetailResponse {
     @QueryProjection
     @Builder
     public CollectingBoxDetailResponse(String location, String roadName, String streetNumber, String modifiedDate,
-                                       String tag) {
+                                       Tag tag) {
         this.location = location;
         this.roadName = roadName;
         this.streetNumber = streetNumber;
         this.modifiedDate = DateUtils.formatDate(modifiedDate);
-        this.tag = Tag.of(tag);
+        this.tag = tag.getLabel();
     }
 
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxDetailResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxDetailResponse.java
@@ -1,13 +1,11 @@
 package contest.collectingbox.module.collectingbox.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import contest.collectingbox.global.common.CommonUtils;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.review.dto.ReviewResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
-import javax.management.Descriptor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,14 +35,8 @@ public class CollectingBoxDetailResponse {
         this.location = location;
         this.roadName = roadName;
         this.streetNumber = streetNumber;
-        this.modifiedDate = formatDate(modifiedDate);
+        this.modifiedDate = CommonUtils.formatDate(modifiedDate);
         this.tag = Tag.of(tag);
-    }
-
-    private String formatDate(String inputDate) {
-        LocalDateTime dateTime = LocalDateTime.parse(inputDate,
-                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
-        return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
     }
 
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxDetailResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxDetailResponse.java
@@ -1,7 +1,7 @@
 package contest.collectingbox.module.collectingbox.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import contest.collectingbox.global.common.CommonUtils;
+import contest.collectingbox.global.common.DateUtils;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.review.dto.ReviewResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -35,7 +35,7 @@ public class CollectingBoxDetailResponse {
         this.location = location;
         this.roadName = roadName;
         this.streetNumber = streetNumber;
-        this.modifiedDate = CommonUtils.formatDate(modifiedDate);
+        this.modifiedDate = DateUtils.formatDate(modifiedDate);
         this.tag = Tag.of(tag);
     }
 

--- a/src/main/java/contest/collectingbox/module/review/dto/ReviewResponse.java
+++ b/src/main/java/contest/collectingbox/module/review/dto/ReviewResponse.java
@@ -1,9 +1,8 @@
 package contest.collectingbox.module.review.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import contest.collectingbox.global.common.CommonUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,12 +18,7 @@ public class ReviewResponse {
     @QueryProjection
     public ReviewResponse(String content, String createdDate) {
         this.content = content;
-        this.createdDate = formatDate(createdDate);
+        this.createdDate = CommonUtils.formatDate(createdDate);
     }
 
-    private String formatDate(String inputDate) {
-        LocalDateTime dateTime = LocalDateTime.parse(inputDate,
-                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
-        return dateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"));
-    }
 }

--- a/src/main/java/contest/collectingbox/module/review/dto/ReviewResponse.java
+++ b/src/main/java/contest/collectingbox/module/review/dto/ReviewResponse.java
@@ -1,7 +1,7 @@
 package contest.collectingbox.module.review.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import contest.collectingbox.global.common.CommonUtils;
+import contest.collectingbox.global.common.DateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +18,7 @@ public class ReviewResponse {
     @QueryProjection
     public ReviewResponse(String content, String createdDate) {
         this.content = content;
-        this.createdDate = CommonUtils.formatDate(createdDate);
+        this.createdDate = DateUtils.formatDate(createdDate);
     }
 
 }

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -7,6 +7,7 @@ import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.location.domain.Location;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -78,10 +79,12 @@ class CollectingBoxServiceTest {
                 .roadName("roadName")
                 .streetNumber("streetNumber")
                 .modifiedDate("2024-04-12 00:00:00.000000")
-                .tag("tag")
+                .tag("CLOTHES")
                 .build();
+        CollectingBox box = CollectingBox.builder().id(collectionId).build();
 
         // when
+        when(collectingBoxRepository.findById(collectionId)).thenReturn(Optional.ofNullable(box));
         when(collectingBoxRepository.findDetailById(collectionId)).thenReturn(expectedResponse);
         CollectingBoxDetailResponse response = collectingBoxService.findBoxDetailById(collectionId);
 

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -79,7 +79,7 @@ class CollectingBoxServiceTest {
                 .roadName("roadName")
                 .streetNumber("streetNumber")
                 .modifiedDate("2024-04-12 00:00:00.000000")
-                .tag("CLOTHES")
+                .tag(CLOTHES)
                 .build();
         CollectingBox box = CollectingBox.builder().id(collectionId).build();
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 수거함 상세보기 조회 시 존재하지 않는 수거함일 경우 예외 처리
- [x] 공통 메소드 클래스 생성 후 날짜 변환 메소드 추가
- [x] IllegalArgumentException 처리 핸들러 추가

## 💡 자세한 설명
- 중복으로 사용되는 메소드들을 관리하기 위해 공통 메소드 클래스 CommonUtils.java를 생성했습니다.
- 공통적으로 발생할 IllegalArgumentException을 처리하기 위한 메서드를 추가했습니다.
- DB에서 가져온 날짜 형식이 잘못되었을 때 발생하는 DateTimeParseException의 예외처리를 했습니다. 
  변환 실패시 우선 null로 반환하도록 했는데, 추후 반환 값에 대해 더 고민해봐야 할 것 같습니다. 



## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #42
