### PR TITLE
공공데이터 API 호출 및 주소 검색 키워드 추출 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    implementation 'org.json:json:20240303'
 }
 
 tasks.named('test') {

--- a/src/main/java/contest/collectingbox/module/publicdata/LoadPublicDataRequest.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/LoadPublicDataRequest.java
@@ -1,0 +1,16 @@
+package contest.collectingbox.module.publicdata;
+
+import contest.collectingbox.module.collectingbox.domain.Tag;
+import lombok.Data;
+
+@Data
+public class LoadPublicDataRequest {
+
+    private String sigungu;
+    private Tag tag;
+    private String callAddress;
+
+    public String getUrlWithPerPage(String apiKey, int perPage) {
+        return String.format("https://api.odcloud.kr/api%s?serviceKey=%s&perPage=%d", callAddress, apiKey, perPage);
+    }
+}

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiController.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiController.java
@@ -1,0 +1,62 @@
+package contest.collectingbox.module.publicdata;
+
+import contest.collectingbox.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PublicDataApiController {
+
+    private static final String TOTAL_COUNT_KEY = "totalCount";
+
+    private final PublicDataService publicDataService;
+
+    @Value("${public-data.api.key}")
+    private String apiKey;
+
+    @PostMapping("/public-data/load")
+    public ApiResponse<Long> loadPublicData(@RequestBody List<LoadPublicDataRequest> requests) {
+        long loadedDataCount = 0;
+        for (LoadPublicDataRequest request : requests) {
+            try {
+                System.out.printf("======= %s - %s =======%n", request.getSigungu(), request.getTag().getLabel());
+                int totalCount = getTotalCountOfPublicData(request);
+                loadedDataCount += publicDataService.loadPublicData(callPublicDataApi(request, totalCount));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return ApiResponse.ok(loadedDataCount);
+    }
+
+    private JSONObject callPublicDataApi(LoadPublicDataRequest request, int perPage) throws IOException {
+        URL url = new URL(request.getUrlWithPerPage(apiKey, perPage));
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        urlConnection.setRequestMethod(HttpMethod.GET.name());
+        urlConnection.setRequestProperty("Content-type", "application/json");
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
+        return new JSONObject(br.readLine());
+    }
+
+    private int getTotalCountOfPublicData(LoadPublicDataRequest request) throws IOException {
+        return Integer.parseInt(callPublicDataApi(request, 1).get(TOTAL_COUNT_KEY).toString());
+    }
+}

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
@@ -1,0 +1,28 @@
+package contest.collectingbox.module.publicdata;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+public class PublicDataExtract {
+
+    private static final String[] KEYWORDS = {"도로", "지번", "주소"};
+
+    public String extractQuery(JSONObject jsonObject) {
+        Set<String> keySet = jsonObject.keySet();
+        for (String key : keySet) {
+            if (StringUtils.containsAny(key, KEYWORDS)) {
+                return jsonObject.get(key).toString();
+            }
+        }
+        log.error("Not contains anything!!!");
+
+        return null;
+    }
+}
+

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -1,0 +1,39 @@
+package contest.collectingbox.module.publicdata;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PublicDataService {
+
+    private final PublicDataExtract publicDataExtract;
+
+    public long loadPublicData(JSONObject jsonObject) {
+        long loadedDataCount = 0;
+        JSONArray jsonArray = (JSONArray) jsonObject.get("data");
+
+        Set<String> querySet = new HashSet<>();
+        for (Object o : jsonArray) {
+            JSONObject object = (JSONObject) o;
+            querySet.add(publicDataExtract.extractQuery(object));
+        }
+
+        for (String query : querySet) {
+            System.out.println(query);
+            loadedDataCount++;
+
+            // 주소 검색 API 호출(query)
+            // DTO 매핑
+        }
+
+        return loadedDataCount;
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] json 라이브러리 의존성 추가
- [x] 공공데이터 API 호출 및 주소 검색 키워드 추출 로직 구현

## 💡 자세한 설명
### 공공데이터 포털 API 호출
```java
private JSONObject callPublicDataApi(LoadPublicDataRequest request, int perPage) throws IOException {
    URL url = new URL(request.getUrlWithPerPage(apiKey, perPage));
    HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
    urlConnection.setRequestMethod(HttpMethod.GET.name());
    urlConnection.setRequestProperty("Content-type", "application/json");

    BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
    return new JSONObject(br.readLine());
}
```
가장 먼저 요청 시 전달 받은 DTO를 통해 URL 객체를 생성합니다. 그 후 HttpURLConnection을 통해 해당 URL과 통신하여 JSON 객체를 응답 받아옵니다.

### 공공데이터 모두 가져오기
```java
@PostMapping("/public-data/load")
public ApiResponse<Long> loadPublicData(@RequestBody List<LoadPublicDataRequest> requests) {
    ...
    int totalCount = getTotalCountOfPublicData(request);
    loadedDataCount += publicDataService.loadPublicData(callPublicDataApi(request, totalCount));
    ...
}
    
private int getTotalCountOfPublicData(LoadPublicDataRequest request) throws IOException {
    return Integer.parseInt(callPublicDataApi(request, 1).get(TOTAL_COUNT_KEY).toString());
}
```
공공데이터 API 호출 시 페이징 처리되기 때문에, 각 공공데이터의 전체 개수를 먼저 읽어온 후 해당 개수로 다시 조회했습니다.

### 주소 검색 키워드 추출
```java
@Slf4j
@Component
public class PublicDataExtract {

    private static final String[] KEYWORDS = {"도로", "지번", "주소"};

    public String extractQuery(JSONObject jsonObject) {
        Set<String> keySet = jsonObject.keySet();
        for (String key : keySet) {
            if (StringUtils.containsAny(key, KEYWORDS)) {
                return jsonObject.get(key).toString();
            }
        }
        log.error("Not contains anything!!!");

        return null;
    }
}
```
주소 검색 API 호출 시 전달할 키워드를 추출하기 위해, 위와 같은 로직을 구현했습니다.
JSON 객체의 key 집합에서 특정 키워드를 포함하고 있는 key를 찾습니다. 그리고나서 그 key에 해당하는 value를 반환합니다.

특정 키워드를 포함하는 key가 존재하지 않는 경우 별도 처리는 추후 이어서 구현하겠습니다.

### 중복 데이터 제거
```java
long loadedDataCount = 0;
JSONArray jsonArray = (JSONArray) jsonObject.get("data");

Set<String> querySet = new HashSet<>();
for (Object o : jsonArray) {
    JSONObject object = (JSONObject) o;
    querySet.add(publicDataExtract.extractQuery(object));
}

for (String query : querySet) {
    System.out.println(query);
    loadedDataCount++;
    ...
```
몇몇 API에서 중복 데이터가 있음을 인지했습니다. 한 예로, 도로명 주소가 '서울시 중랑구 망우로'이면서 다른 컬럼의 값이 다른 데이터가 있었습니다.
따라서 추출한 도로명 또는 지번 주소 키워드를 Set 자료구조에 저장함으로써 중복 문제를 해결했습니다.

### API 테스트 결과
<img width="1076" alt="image" src="https://github.com/CollectingBox/server/assets/110653660/03043416-021e-494d-bcd3-0a0c56bb2439">

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #45 
