### PR TITLE
카카오 주소 변환 API 호출 및 DTO 변환

### DIFF
--- a/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
@@ -1,0 +1,39 @@
+package contest.collectingbox.module.publicdata;
+
+import contest.collectingbox.module.collectingbox.domain.Tag;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class AddressInfoResponse {
+    private String longitude;
+    private String latitude;
+    private String sido;
+    private String sigungu;
+    private String dong;
+    private String road_name;
+    private String street_num;
+    private String name;
+    private Tag tag;
+
+    @Builder
+    public AddressInfoResponse(String longitude, String latitude, String sido, String sigungu, String dong,
+                               String road_name, String street_num, String name, Tag tag) {
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.sido = sido;
+        this.sigungu = sigungu;
+        this.dong = dong;
+        this.road_name = road_name;
+        this.street_num = street_num;
+        this.name = name;
+        this.tag = tag;
+    }
+
+}

--- a/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
@@ -17,21 +17,21 @@ public class AddressInfoResponse {
     private String sido;
     private String sigungu;
     private String dong;
-    private String road_name;
-    private String street_num;
+    private String roadName;
+    private String streetNum;
     private String name;
     private Tag tag;
 
     @Builder
     public AddressInfoResponse(String longitude, String latitude, String sido, String sigungu, String dong,
-                               String road_name, String street_num, String name, Tag tag) {
+                               String roadName, String streetNum, String name, Tag tag) {
         this.longitude = longitude;
         this.latitude = latitude;
         this.sido = sido;
         this.sigungu = sigungu;
         this.dong = dong;
-        this.road_name = road_name;
-        this.street_num = street_num;
+        this.roadName = roadName;
+        this.streetNum = streetNum;
         this.name = name;
         this.tag = tag;
     }

--- a/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
@@ -2,7 +2,6 @@ package contest.collectingbox.module.publicdata;
 
 import static java.nio.charset.StandardCharsets.*;
 
-import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
@@ -80,8 +80,8 @@ public class KakaoApiManager {
                 .sido(address.getString("region_1depth_name"))
                 .sigungu(address.getString("region_2depth_name"))
                 .dong(address.getString("region_3depth_name"))
-                .road_name(roadAddress.getString("address_name"))
-                .street_num(address.getString("address_name"))
+                .roadName(roadAddress.getString("address_name"))
+                .streetNum(address.getString("address_name"))
                 .name(detailName)
                 .tag(tag)
                 .build();

--- a/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
@@ -1,0 +1,91 @@
+package contest.collectingbox.module.publicdata;
+
+import static java.nio.charset.StandardCharsets.*;
+
+import contest.collectingbox.global.exception.CollectingBoxException;
+import contest.collectingbox.module.collectingbox.domain.Tag;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoApiManager {
+    @Value("${kakao.api.key}")
+    private String apiKey;
+    private final String apiUrl = "https://dapi.kakao.com/v2/local/search/address.json";
+
+    public AddressInfoResponse fetchAddressInfo(String query, Tag tag) {
+        try {
+
+            ResponseEntity<String> response = callKakaoAPI(query);
+            if (response.getStatusCode() != HttpStatus.OK) {
+                log.error("Kakao API call failed status : {}", response.getStatusCode());
+                throw new RuntimeException("Kakao API fail exception");
+            }
+
+            JSONObject jsonObject = new JSONObject(response.getBody());
+            JSONArray documents = jsonObject.getJSONArray("documents");
+
+            if (documents.isEmpty()) { // API 호출 후 응답값이 없는 경우 추후 처리 필요
+                log.warn("No address information found for query: {}", query);
+                return null;
+            }
+
+            JSONObject document = documents.getJSONObject(0);
+            return makeAddressDto(document, tag);
+        } catch (JSONException e) {
+            log.error("Error parsing JSON from Kakao API : {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ResponseEntity<String> callKakaoAPI(String query) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set("Authorization", "KakaoAK " + apiKey);
+        HttpEntity<Object> httpEntity = new HttpEntity<>(httpHeaders);
+        URI targetUrl = UriComponentsBuilder.fromUriString(apiUrl).queryParam("query", query)
+                .build().encode(UTF_8).toUri();
+
+        return restTemplate.exchange(targetUrl, HttpMethod.GET, httpEntity,
+                String.class);
+    }
+
+    private AddressInfoResponse makeAddressDto(JSONObject document, Tag tag) {
+        JSONObject address = document.getJSONObject("address");
+        JSONObject roadAddress = document.getJSONObject("road_address");
+
+        String buildingName = roadAddress.getString("building_name");
+        String detailName = buildingName.isEmpty() ?
+                (tag.name().equals("TRASH") ? tag.getLabel() : tag.getLabel() + " 수거함")
+                : buildingName;
+
+        return AddressInfoResponse.builder()
+                .longitude(document.getString("x"))
+                .latitude(document.getString("y"))
+                .sido(address.getString("region_1depth_name"))
+                .sigungu(address.getString("region_2depth_name"))
+                .dong(address.getString("region_3depth_name"))
+                .road_name(roadAddress.getString("address_name"))
+                .street_num(address.getString("address_name"))
+                .name(detailName)
+                .tag(tag)
+                .build();
+
+    }
+}

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiController.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiController.java
@@ -37,7 +37,8 @@ public class PublicDataApiController {
             try {
                 System.out.printf("======= %s - %s =======%n", request.getSigungu(), request.getTag().getLabel());
                 int totalCount = getTotalCountOfPublicData(request);
-                loadedDataCount += publicDataService.loadPublicData(callPublicDataApi(request, totalCount));
+                loadedDataCount += publicDataService.loadPublicData(callPublicDataApi(request, totalCount), request.getTag());
+
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
@@ -11,15 +11,18 @@ import java.util.Set;
 @Component
 public class PublicDataExtract {
 
-    private static final String[] KEYWORDS = {"도로", "지번", "주소"};
+    private static final String[] KEYWORDS = {"도로", "지번", "주소", "소재지", "위치", "장소"};
 
     public String extractQuery(JSONObject jsonObject) {
         Set<String> keySet = jsonObject.keySet();
-        for (String key : keySet) {
-            if (StringUtils.containsAny(key, KEYWORDS)) {
-                return jsonObject.get(key).toString();
+        for (String keyword : KEYWORDS) {
+            for (String key : keySet) {
+                if (key.contains(keyword) && !jsonObject.get(key).toString().isBlank()) {
+                    return jsonObject.get(key).toString();
+                }
             }
         }
+
         log.error("Not contains anything!!!");
 
         return null;

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -1,5 +1,6 @@
 package contest.collectingbox.module.publicdata;
 
+import contest.collectingbox.module.collectingbox.domain.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
@@ -15,8 +16,10 @@ import java.util.Set;
 public class PublicDataService {
 
     private final PublicDataExtract publicDataExtract;
+    private final KakaoApiManager kakaoApiManager;
 
-    public long loadPublicData(JSONObject jsonObject) {
+
+    public long loadPublicData(JSONObject jsonObject, Tag tag) {
         long loadedDataCount = 0;
         JSONArray jsonArray = (JSONArray) jsonObject.get("data");
 
@@ -27,11 +30,13 @@ public class PublicDataService {
         }
 
         for (String query : querySet) {
-            System.out.println(query);
             loadedDataCount++;
 
-            // 주소 검색 API 호출(query)
-            // DTO 매핑
+            // query -> kakaoApi -> DTO
+            AddressInfoResponse response = kakaoApiManager.fetchAddressInfo(query, tag);
+            log.info("query = {}, response = {}", query, response);
+
+            // insert DB
         }
 
         return loadedDataCount;


### PR DESCRIPTION
## 💡 작업 내용
- [x] 카카오 주소 변환 API 호출
- [x] API 응답 값 DTO 변환
- [x] 카카오 API 호출 시 필요한 query 키워드 추가

## 💡 자세한 설명

### Kakao Rest API 호출

- Kakao Rest API 를 호출하기 위해 RestTemplate를 사용했습니다. 
*RestTemplate: HTTP 서버와 쉽게 통신 가능한 자바 라이브러로 응답을 JSON으로 쉽게 변환 가능 

```java
    private ResponseEntity<String> callKakaoAPI(String query) {
        RestTemplate restTemplate = new RestTemplate();
        HttpHeaders httpHeaders = new HttpHeaders();
        httpHeaders.set("Authorization", "KakaoAK " + apiKey);
        HttpEntity<Object> httpEntity = new HttpEntity<>(httpHeaders);
        URI targetUrl = UriComponentsBuilder.fromUriString(apiUrl).queryParam("query", query)
                .build().encode(UTF_8).toUri();

        return restTemplate.exchange(targetUrl, HttpMethod.GET, httpEntity,
                String.class);
    }
```

HTTP 요청 헤더에는 apiKey를 포함한 Authorization 헤더를 설정 한 후 HttpEntity에 포함합니다. 
주어진 쿼리를 쿼리 매개변수로하여 API의 URL을 생성하고, 이를 이용하여 RestTemplate의 exchange 메서드를 호출하여 GET 요청을 보냅니다.

### JSON으로 파싱 및 DTO 변환

```java
    public AddressInfoResponse fetchAddressInfo(String query, Tag tag) {
        try {

            ResponseEntity<String> response = callKakaoAPI(query);
            if (response.getStatusCode() != HttpStatus.OK) {
                log.error("Kakao API call failed status : {}", response.getStatusCode());
                throw new RuntimeException("Kakao API fail exception");
            }

            JSONObject jsonObject = new JSONObject(response.getBody());
            JSONArray documents = jsonObject.getJSONArray("documents");

            if (documents.isEmpty()) { // API 호출 후 응답값이 없는 경우 추후 처리 필요
                log.warn("No address information found for query: {}", query);
                return null;
            }

            JSONObject document = documents.getJSONObject(0);
            return makeAddressDto(document, tag);
        } catch (JSONException e) {
            log.error("Error parsing JSON from Kakao API : {}", e.getMessage());
            throw new RuntimeException(e);
        }
    }
```

반환된 ResponseEntity를 JSONObject를 통해 JSON으로 파싱하고 DB 삽입을 위한 DTO에 매핑합니다. 

### 추후 고민 및 처리 사항
- 몇몇 주소 query의 Kakao API 응답이 빈 배열로 오는 경우 처리 
- 카카오 API 호출 실패 시, JSON 파싱 실패 시 등의 예외 처리
- API 호출 URL들 별도 클래스 분리 

## 📗 참고 자료

https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html


## 🚩 후속 작업
- 예외 처리 및 패키지/클래스 리팩토링

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #47
