### PR TITLE
공공데이터 API 관련 정보 저장 기능 구현

### DIFF
--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiController.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiController.java
@@ -30,6 +30,12 @@ public class PublicDataApiController {
     @Value("${public-data.api.key}")
     private String apiKey;
 
+    @PostMapping("/public-data/info")
+    public ApiResponse<Integer> savePublicDataApiInfo(@RequestBody List<SavePublicDataApiInfoRequest> requests) {
+        publicDataService.savePublicDataApiInfo(requests);
+        return ApiResponse.ok(requests.size());
+    }
+
     @PostMapping("/public-data/load")
     public ApiResponse<Long> loadPublicData(@RequestBody List<LoadPublicDataRequest> requests) {
         long loadedDataCount = 0;

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiInfo.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiInfo.java
@@ -1,0 +1,30 @@
+package contest.collectingbox.module.publicdata;
+
+import contest.collectingbox.module.collectingbox.domain.Tag;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PublicDataApiInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String sido;
+
+    @Column(nullable = false)
+    private String sigungu;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Tag tag;
+
+    @Column(nullable = false)
+    private String callAddress;
+}

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataApiInfoRepository.java
@@ -1,0 +1,6 @@
+package contest.collectingbox.module.publicdata;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PublicDataApiInfoRepository extends JpaRepository<PublicDataApiInfo, Long> {
+}

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Slf4j
@@ -15,9 +16,15 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class PublicDataService {
 
+    private final PublicDataApiInfoRepository publicDataApiInfoRepository;
     private final PublicDataExtract publicDataExtract;
     private final KakaoApiManager kakaoApiManager;
 
+    public void savePublicDataApiInfo(List<SavePublicDataApiInfoRequest> requests) {
+        for (SavePublicDataApiInfoRequest request : requests) {
+            publicDataApiInfoRepository.save(request.toEntity());
+        }
+    }
 
     public long loadPublicData(JSONObject jsonObject, Tag tag) {
         long loadedDataCount = 0;

--- a/src/main/java/contest/collectingbox/module/publicdata/SavePublicDataApiInfoRequest.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/SavePublicDataApiInfoRequest.java
@@ -1,0 +1,23 @@
+package contest.collectingbox.module.publicdata;
+
+import contest.collectingbox.module.collectingbox.domain.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SavePublicDataApiInfoRequest {
+    private String sido;
+    private String sigungu;
+    private Tag tag;
+    private String callAddress;
+
+    public PublicDataApiInfo toEntity() {
+        return PublicDataApiInfo.builder()
+                .sido(sido)
+                .sigungu(sigungu)
+                .tag(tag)
+                .callAddress(callAddress)
+                .build();
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] 공공데이터 API 관련 정보 저장 기능 구현

## 💡 자세한 설명
수거함 정보를 업데이트하기 위해 공공데이터 API에 대한 정보를 매번 전달하게 되면, 해당 데이터를 외부에 보관해야 하므로 비효율적이라고 생각했습니다. 또한 공공데이터 API에 대한 정보는 자주 변경되지 않을 것이라 판단했습니다.
이러한 이유로 해당 정보를 DB에서 관리하기로 했습니다.

<img width="458" alt="image" src="https://github.com/CollectingBox/server/assets/110653660/65cc984d-4ce4-4c47-a610-f35d6169b0fe">

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #51 
