### PR TITLE
카카오 주소 검색 API 호출 로직 마무리

### DIFF
--- a/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
@@ -1,19 +1,17 @@
 package contest.collectingbox.module.publicdata;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @ToString
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class AddressInfoResponse {
-    private String longitude;
-    private String latitude;
+    private Double longitude;
+    private Double latitude;
     private String sido;
     private String sigungu;
     private String dong;
@@ -22,18 +20,13 @@ public class AddressInfoResponse {
     private String name;
     private Tag tag;
 
-    @Builder
-    public AddressInfoResponse(String longitude, String latitude, String sido, String sigungu, String dong,
-                               String roadName, String streetNum, String name, Tag tag) {
-        this.longitude = longitude;
-        this.latitude = latitude;
-        this.sido = sido;
-        this.sigungu = sigungu;
-        this.dong = dong;
-        this.roadName = roadName;
-        this.streetNum = streetNum;
-        this.name = name;
-        this.tag = tag;
+    public boolean hasNull() {
+        return longitude == null ||
+                latitude == null ||
+                sido == null ||
+                sigungu == null ||
+                dong == null ||
+                (name == null && roadName == null && streetNum == null) ||
+                tag == null;
     }
-
 }

--- a/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
@@ -1,36 +1,32 @@
 package contest.collectingbox.module.publicdata;
 
-import static java.nio.charset.StandardCharsets.*;
-
 import contest.collectingbox.module.collectingbox.domain.Tag;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class KakaoApiManager {
+    private static final String API_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
     @Value("${kakao.api.key}")
     private String apiKey;
-    private final String apiUrl = "https://dapi.kakao.com/v2/local/search/address.json";
 
     public AddressInfoResponse fetchAddressInfo(String query, Tag tag) {
         try {
-
             ResponseEntity<String> response = callKakaoAPI(query);
             if (response.getStatusCode() != HttpStatus.OK) {
                 log.error("Kakao API call failed status : {}", response.getStatusCode());
@@ -58,11 +54,10 @@ public class KakaoApiManager {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.set("Authorization", "KakaoAK " + apiKey);
         HttpEntity<Object> httpEntity = new HttpEntity<>(httpHeaders);
-        URI targetUrl = UriComponentsBuilder.fromUriString(apiUrl).queryParam("query", query)
+        URI targetUrl = UriComponentsBuilder.fromUriString(API_URL).queryParam("query", query)
                 .build().encode(UTF_8).toUri();
 
-        return restTemplate.exchange(targetUrl, HttpMethod.GET, httpEntity,
-                String.class);
+        return restTemplate.exchange(targetUrl, HttpMethod.GET, httpEntity, String.class);
     }
 
     private AddressInfoResponse makeAddressDto(JSONObject document, Tag tag) {

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
@@ -1,7 +1,6 @@
 package contest.collectingbox.module.publicdata;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
@@ -17,15 +16,14 @@ public class PublicDataExtract {
         Set<String> keySet = jsonObject.keySet();
         for (String keyword : KEYWORDS) {
             for (String key : keySet) {
-                if (key.contains(keyword) && !jsonObject.get(key).toString().isBlank()) {
+                if (key.contains(keyword) && !jsonObject.isNull(key)) {
                     return jsonObject.get(key).toString();
                 }
             }
         }
 
-        log.error("Not contains anything!!!");
+        log.error("Not contains anything in {}", jsonObject);
 
         return null;
     }
 }
-

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -37,13 +37,28 @@ public class PublicDataService {
         }
 
         for (String query : querySet) {
-            loadedDataCount++;
+            // 검색 키워드 null 체크
+            if (query == null) {
+                continue;
+            }
 
-            // query -> kakaoApi -> DTO
+            // 카카오 주소 검색 API 호출
             AddressInfoResponse response = kakaoApiManager.fetchAddressInfo(query, tag);
+
+            // 카카오 주소 검색 API 응답 null 체크
+            if (response == null) {
+                continue;
+            }
+
+            if (response.hasNull()) {
+                throw new RuntimeException("null");
+            }
+
+            // 카카오 주소 검색 API 응답 출력
             log.info("query = {}, response = {}", query, response);
 
             // insert DB
+            loadedDataCount++;
         }
 
         return loadedDataCount;


### PR DESCRIPTION
## 💡 작업 내용
- [x] 공공데이터 null 체크
- [x] DTO 스펙 수정
- [x] 카카오 API 응답의 JSON 형식에 따른 분기 처리
- [x] 카카오 API 응답 null 체크

## 💡 자세한 설명
### 공공데이터 null 체크
공공데이터 API 응답 내 도로명 주소와 지번 주소 중 null이 존재하는 key를 발견했습니다.
따라서 다음과 같이 null 체크를 통해 오류가 발생하지 않도록 했습니다.
```java
if (key.contains(keyword) && !jsonObject.isNull(key)) {
    return jsonObject.get(key).toString();
}
```
공공데이터 API 호출을 통해 응답으로 온 JSON 객체에서 key 값이 null인 경우 제외하도록 하였습니다.

### 카카오 API 응답 분기 처리
공공데이터 API의 응답에서 추출한 검색 키워드로 카카오의 주소 검색 API를 호출하면, 다음과 같이 null이 담겨 있는 key가 존재할 수 있습니다.

![image](https://github.com/CollectingBox/server/assets/110653660/ab2de0bd-6ac4-4aa3-af7a-eb0608b602a1)

따라서 다음과 같이 null이 아닌 key를 기준으로 데이터를 가져오도록 구현했습니다.
```java
private AddressInfoResponse makeAddressDto(JSONObject document, Tag tag) {
        AddressInfoResponse.AddressInfoResponseBuilder builder = AddressInfoResponse.builder()
                .longitude(document.getDouble("x"))
                .latitude(document.getDouble("y"))
                .tag(tag);

        if (document.isNull("address")) {
            return getRoadAddressInfo(document, tag, builder);
        }

        if (document.isNull("road_address")) {
            return getAddressInfo(document, builder);
        }

        return getAddressInfoResponse(document, tag, builder);
}
```

### 카카오 API 응답 null 체크
공공데이터 API 응답에서 추출한 검색 키워드로 주소를 검색했을 때, 정상적으로 검색되지 않는 경우가 존재합니다.
이러한 원인은 공공데이터가 잘못 기입되어 있음으로 판단했습니다. 따라서 카카오 API 응답이 null인 경우 건너뛰도록 구현했습니다.

### 예외를 던짐으로써 잘못된 데이터 임시 확인
응답(AddressInfoResponse) 내 필드 중 하나라도 null일 경우 예외를 발생시킴으로써, 불러온 데이터 중 잘못된 데이터는 없는지 확인합니다.

> 모든 코드에서 개선할 점이 많이 보이지만, 우선 기능 구현 후 여유가 된다면 개선하려고 합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #54 
