### PR TITLE
공공데이터 DB 저장 기능 구현

### DIFF
--- a/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
@@ -38,18 +38,22 @@ public class AddressInfoResponse {
         Location location = Location.builder()
                 .name(name)
                 .point(GeometryUtil.toPoint(longitude, latitude))
-                .address(Address.builder()
-                        .sido(sido)
-                        .sigungu(sigungu)
-                        .dong(dong)
-                        .roadName(roadName)
-                        .streetNum(streetNum)
-                        .build())
+                .address(getAddress(sido, sigungu, dong, roadName, streetNum))
                 .build();
 
         return CollectingBox.builder()
                 .location(location)
                 .tag(tag)
+                .build();
+    }
+
+    private Address getAddress(String sido, String sigungu, String dong, String roadName, String streetNum) {
+        return Address.builder()
+                .sido(sido)
+                .sigungu(sigungu)
+                .dong(dong)
+                .roadName(roadName)
+                .streetNum(streetNum)
                 .build();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 공공데이터 API 호출 -> 카카오 API로 가공한 데이터들 DB에 저장

## 💡 자세한 설명

### 공공데이터 CollectionBox 테이블과 Location 테이블에 저장
collectionBoxRepository에 collectionBox 엔티티를 저장할 때 아래와 같은 JPA Hibernate 에러가 발생했습니다. 

`TransientPropertyValueException: object references an unsaved transient instance - save the transient instance before flushing`
이 에러는 연관된 엔티티 중 저장되지 않은(transient) 엔티티를 참조할 때 발생합니다.
Location 엔티티는 CollectingBox에 의해 참조되는데, CollectingBox가 저장되기 전에 저장되지 않았기 때문에 해당 에러가 발생한 것입니다. 


```java
public class CollectingBox extends BaseTimeEntity {

    ...
    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
    @JoinColumn(name = "location_id")
    private Location location;
    ...
}
```

cascade = CascadeType.ALL을 사용해 문제를 해결했습니다.
이 속성을 사용하면 CollectingBox 엔티티를 저장할 때 location 필드에 있는 Location 엔티티도 함께 저장됩니다. 
CollectingBox를 저장할 때 Location 엔티티가 영속화되어 있어서 에러가 발생하지 않습니다.


## 📗 참고 자료 
https://umanking.github.io/2019/04/12/jpa-cascade/


## 🚩 후속 작업 

### 데이터 테이블에 삽입 시 null 값 저장 현상
![image](https://github.com/CollectingBox/server/assets/71643491/4483afed-a792-4482-9f51-7e8d257af01f)

로컬 DB 저장 후, Location 테이블의 name컬럼의 값이 null인 현상이 발견되었습니다. 
해당 현상과 같이 데이터가 이상하게 삽입되거나 null 로 삽입되는 경우들을 살펴보고 원인 파악 후 조치하도록 하겠습니다. 


### 카카오 API 호출 시 파라미터 쿼리 검사
동작구 쓰레기통의 경우, 도로명이 정확히 명시되어 있지 않아 올바르지 않은 파라미터로 카카오 API 요청이 호출되고 있습니다.
해당 작업도 후속 조치할 예정입니다. 


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #49 
