### PR TITLE
공공데이터 정보 빈 값 체크 로직 구현

### DIFF
--- a/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/AddressInfoResponse.java
@@ -34,6 +34,12 @@ public class AddressInfoResponse {
                 tag == null;
     }
 
+    public boolean hasEmptyValue() {
+        return sido.isEmpty() || sigungu.isEmpty() || dong.isEmpty() ||
+                (name.isEmpty() && roadName.isEmpty() && streetNum.isEmpty())
+                || tag.name().isEmpty();
+    }
+
     public CollectingBox toEntity() {
         Location location = Location.builder()
                 .name(name)

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -102,18 +102,19 @@ public class PublicDataService {
             }
             querySet.add(query);
 
-            if (query == null || query.isEmpty()) {
+            if (query.isEmpty()) {
                 continue;
             }
 
             AddressInfoResponse response = kakaoApiManager.fetchAddressInfo(query, tag);
             log.info("query = {}, response = {}", query, response);
 
-            if (response != null) {
-                dataCount++;
-                collectingBoxRepository.save(response.toEntity());
+            if (response == null || response.hasNull() || response.hasEmptyValue()) {
+                continue;
             }
 
+            dataCount++;
+            collectingBoxRepository.save(response.toEntity());
         }
         return dataCount;
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 카카오 API로 받아온 주소 정보 중 빈 값이 있을 시 DB 저장 방지 기능 구현
- [x] 양천구 의류수거함 csv 파일 DB 저장 테스트 완료

## 💡 자세한 설명
주소 정보를 null인지 체크하는 것 만으로는 문자열이 빈 값인지 체크할 수 없었습니다.
따라서 isEmpty()를 사용해 빈 값이 존재하는지 판별하는 메소드를 추가했습니다. 
필요시 기존의 공공데이터 API 호출 후 DB 저장 로직에도 해당 검증을 추가하면 될 것 같습니다. 



## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #69 
