### PR TITLE
검색어 자동완성 중복 문제 해결

### DIFF
--- a/src/main/java/contest/collectingbox/module/autocomplete/application/AutoCompleteService.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/application/AutoCompleteService.java
@@ -22,7 +22,6 @@ public class AutoCompleteService {
                 autoCompleteRepository.findAutoComplete(query)
                         .stream()
                         .map(this::formatAddress)
-                        .distinct()
                         .collect(Collectors.toList());
         return new AutoCompleteResponseDto(items);
     }

--- a/src/main/java/contest/collectingbox/module/autocomplete/application/AutoCompleteService.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/application/AutoCompleteService.java
@@ -22,6 +22,7 @@ public class AutoCompleteService {
                 autoCompleteRepository.findAutoComplete(query)
                         .stream()
                         .map(this::formatAddress)
+                        .distinct()
                         .collect(Collectors.toList());
         return new AutoCompleteResponseDto(items);
     }

--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
@@ -21,7 +21,7 @@ public class AutoCompleteRepositoryImpl implements AutoCompleteRepositoryCustom 
         QLocation location = QLocation.location;
         // SELECT DISTINCT l FROM Location l WHERE l.address.streetNum LIKE %:query% ORDER BY l.address.sigungu, l.address.dong LIMIT 5
         return queryFactory
-                .select(new QAddressDto(location.address.sigungu, location.address.dong))
+                .selectDistinct(new QAddressDto(location.address.sigungu, location.address.dong))
                 .from(location)
                 .where(location.address.streetNum.contains(query))
                 .orderBy(location.address.sigungu.asc(), location.address.dong.asc())


### PR DESCRIPTION
## 💡 작업 내용
- [x] 검색어 자동완성 목록 중복 검색어 문제 해결

## 💡 자세한 설명
검색어 조회 쿼리시 distinct를 사용해 중복 데이터를 조회하지 않도록 수정했습니다. 


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #63 
