### PR TITLE
폐형광등, 폐건전지 태그 통합 구현

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/Tag.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/Tag.java
@@ -8,8 +8,7 @@ import lombok.Getter;
 public enum Tag {
 
     CLOTHES("폐의류"),
-    LAMP("폐형광등"),
-    BATTERY("폐건전지"),
+    LAMP_BATTERY("폐형광등∙건전지"),
     MEDICINE("폐의약품"),
     TRASH("쓰레기통");
 

--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
@@ -23,7 +23,7 @@ public class CollectingBoxResponse {
     private Double longitude;
 
     @Schema(description = "태그", example = "CLOTHES",
-            allowableValues = {"CLOTHES", "LAMP", "BATTERY", "MEDICINE", "TRASH"})
+            allowableValues = {"CLOTHES", "LAMP_BATTERY", "MEDICINE", "TRASH"})
     private String tag;
 
     public static CollectingBoxResponse fromEntity(CollectingBox collectingBox) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -11,11 +11,11 @@ insert into location values (10, '용두 치안센터 쓰레기통', st_geomfrom
 
 insert into collecting_box values (1, 1, 'CLOTHES', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
 insert into collecting_box values (2, 2, 'CLOTHES', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (3, 3, 'BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (4, 4, 'BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (5, 5, 'BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (6, 6, 'BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (7, 7, 'LAMP', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (3, 3, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (4, 4, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (5, 5, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (6, 6, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (7, 7, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
 insert into collecting_box values (8, 8, 'MEDICINE', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
 insert into collecting_box values (9, 9, 'TRASH', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
 insert into collecting_box values (10, 10, 'TRASH', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
@@ -43,9 +43,9 @@ insert into collecting_box values (16, 16, 'CLOTHES', '2024-04-12 00:00:00', '20
 insert into collecting_box values (17, 17, 'CLOTHES', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
 insert into collecting_box values (18, 18, 'CLOTHES', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
 insert into collecting_box values (19, 19, 'CLOTHES', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (20, 20, 'BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (21, 21, 'BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
-insert into collecting_box values (22, 22, 'LAMP', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (20, 20, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (21, 21, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
+insert into collecting_box values (22, 22, 'LAMP_BATTERY', '2024-04-12 00:00:00', '2024-04-12 00:00:00');
 
 -- 강서구 화곡동 폐의류, 폐건전지, 폐형광등, 폐의약품 수거함 + 쓰레기통 (37.5404202469638 126.840017492851)
 insert into location values (23, '뉴파인빌 수거함', st_geomfromtext('point(37.5396125849777 126.840012768981)', 4326), '서울특별시', '강서구', '화곡동', '서울특별시 강서구 강서로31길27', '서울특별시 강서구 화곡동 1078-16', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
@@ -67,11 +67,11 @@ insert into location values (37, '쓰레기통', st_geomfromtext('point(37.54124
 insert into collecting_box values (23, 23, 'CLOTHES', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
 insert into collecting_box values (24, 24, 'CLOTHES', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
 insert into collecting_box values (25, 25, 'CLOTHES', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
-insert into collecting_box values (26, 26, 'BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
-insert into collecting_box values (27, 27, 'BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
-insert into collecting_box values (28, 28, 'BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
-insert into collecting_box values (29, 29, 'LAMP', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
-insert into collecting_box values (30, 30, 'LAMP', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
+insert into collecting_box values (26, 26, 'LAMP_BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
+insert into collecting_box values (27, 27, 'LAMP_BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
+insert into collecting_box values (28, 28, 'LAMP_BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
+insert into collecting_box values (29, 29, 'LAMP_BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
+insert into collecting_box values (30, 30, 'LAMP_BATTERY', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
 insert into collecting_box values (31, 31, 'MEDICINE', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
 insert into collecting_box values (32, 32, 'MEDICINE', '2024-04-18 00:00:00', '2024-04-18 00:00:00');
 insert into collecting_box values (33, 33, 'MEDICINE', '2024-04-18 00:00:00', '2024-04-18 00:00:00');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE collecting_box
 (
     id          BIGINT NOT NULL AUTO_INCREMENT,
     location_id BIGINT,
-    tag         ENUM ('CLOTHES','LAMP','BATTERY','MEDICINE','TRASH') NOT NULL,
+    tag         ENUM ('CLOTHES','LAMP_BATTERY','MEDICINE','TRASH') NOT NULL,
     created_at  DATETIME(6),
     updated_at  DATETIME(6),
     PRIMARY KEY (id)

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -54,7 +54,7 @@ class CollectingBoxServiceTest {
     @DisplayName("위도와 경도를 기준으로 특정 반경에 위치한 수거함 목록 조회 성공")
     void findCollectingBoxesWithinArea_Success_withinArea() {
         // given
-        List<Tag> tags = List.of(CLOTHES, LAMP, BATTERY, MEDICINE, TRASH);
+        List<Tag> tags = List.of(CLOTHES, LAMP_BATTERY, MEDICINE, TRASH);
 
         CollectingBox box = CollectingBox.builder()
                 .id(1L)


### PR DESCRIPTION
## 💡 작업 내용

- [x] 폐형광등과 폐건전지 태그를 하나로 통합해 LAMP_BATTERY 태그를 추가
- [x] data.sql, schema.sql에 사용되는 'LAMP', 'BATTERY' 태그 값 'LAMP_BATTERY' 로 변경

## 💡 자세한 설명

Tag enum에 폐형광등, 폐건전지 태그 삭제 후 LAMP_BATTERY("폐형광등∙건전지")태그를 추가하였습니다. 


## 🚩 후속 작업 

1. 상용 데이터베이스 collection_box 테이블의 tag 칼럼에 'LAMP_BATTERY' enum 값 추가
2. 기존 'LAMP' tag 값 가진 튜플들의 tag 값 'LAMP_BATTERY'로 변경 
3. tag 칼럼 enum 값 'LAMP', 'BATTERY' 삭제

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #75 
