### PR TITLE
공공데이터 키워드 추출시 특이 케이스 처리 구현

### DIFF
--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
@@ -1,5 +1,9 @@
 package contest.collectingbox.module.publicdata;
 
+import static contest.collectingbox.module.collectingbox.domain.Tag.*;
+
+import contest.collectingbox.module.collectingbox.domain.Tag;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
@@ -12,7 +16,12 @@ public class PublicDataExtract {
 
     private static final String[] KEYWORDS = {"도로", "지번", "주소", "소재지", "위치", "장소"};
 
-    public String extractQuery(JSONObject jsonObject) {
+    public String extractQuery(JSONObject jsonObject, String sigungu, Tag tag) {
+        Optional<String> specialValue = extractSpecialCaseValue(jsonObject, sigungu, tag);
+        if (specialValue.isPresent()) {
+            return specialValue.get();
+        }
+
         Set<String> keySet = jsonObject.keySet();
         for (String keyword : KEYWORDS) {
             for (String key : keySet) {
@@ -27,7 +36,12 @@ public class PublicDataExtract {
         return null;
     }
 
-    public int extractCsvQueryIndex(String[] columnNames) {
+    public int extractCsvQueryIndex(String[] columnNames, String sigungu, Tag tag) {
+        int specialCaseIndex = extractSpecialCaseIndex(sigungu, tag);
+        if (specialCaseIndex != -1) {
+            return specialCaseIndex;
+        }
+
         for (String keyword : KEYWORDS) {
             for (int i = 0; i < columnNames.length; i++) {
                 if (columnNames[i].contains(keyword)) {
@@ -36,6 +50,20 @@ public class PublicDataExtract {
             }
         }
         log.error("No csv column name containing keywords, columnNames = {}", (Object) columnNames);
+        return -1;
+    }
+
+    private Optional<String> extractSpecialCaseValue(JSONObject jsonObject, String sigungu, Tag tag) {
+        if (sigungu.equals("강북구") && tag == TRASH) {
+            return Optional.of(jsonObject.optString("세부 위치"));
+        }
+        return Optional.empty();
+    }
+
+    private int extractSpecialCaseIndex(String sigungu, Tag tag) {
+        if (sigungu.equals("구로구") && tag == TRASH) {
+            return 1; // 소재지가로명주소
+        }
         return -1;
     }
 }

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -41,7 +41,7 @@ public class PublicDataService {
         Set<String> querySet = new HashSet<>();
         for (Object o : jsonArray) {
             JSONObject object = (JSONObject) o;
-            querySet.add(publicDataExtract.extractQuery(object));
+            querySet.add(publicDataExtract.extractQuery(object, sigungu, tag));
         }
 
         for (String query : querySet) {
@@ -63,7 +63,7 @@ public class PublicDataService {
             }
 
             // 카카오 주소 검색 API 응답 출력
-            log.info("query = {}, response = {}", query, response);
+            log.info("'LAMP_BATTERY'{}, response = {}", query, response);
 
             // insert DB
             if (equals(response.getSigungu(), sigungu)) {
@@ -81,7 +81,8 @@ public class PublicDataService {
             CSVReader csvReader = new CSVReader(new InputStreamReader(
                     Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream(fileName)), "EUC-KR"));
 
-            int columnIndex = publicDataExtract.extractCsvQueryIndex(csvReader.readNext());
+            int columnIndex = publicDataExtract.extractCsvQueryIndex(csvReader.readNext(), request.getSigungu(),
+                    request.getTag());
             if (columnIndex == -1) {
                 return 0;
             }
@@ -92,7 +93,8 @@ public class PublicDataService {
         }
     }
 
-    private long saveCsvPublicData(CSVReader csvReader, int index, String sigungu, Tag tag) throws CsvValidationException, IOException {
+    private long saveCsvPublicData(CSVReader csvReader, int index, String sigungu, Tag tag)
+            throws CsvValidationException, IOException {
         long dataCount = 0;
         String[] line;
         Set<String> querySet = new HashSet<>();
@@ -101,6 +103,7 @@ public class PublicDataService {
             if (querySet.contains(query)) {
                 continue;
             }
+            System.out.println("query = " + query);
             querySet.add(query);
 
             if (query.isBlank()) {
@@ -113,7 +116,7 @@ public class PublicDataService {
             if (response == null || response.hasNull() || response.hasEmptyValue()) {
                 continue;
             }
-          
+
             if (equals(response.getSigungu(), sigungu)) {
                 dataCount++;
                 collectingBoxRepository.save(response.toEntity());

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -103,7 +103,6 @@ public class PublicDataService {
             if (querySet.contains(query)) {
                 continue;
             }
-            System.out.println("query = " + query);
             querySet.add(query);
 
             if (query.isBlank()) {

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -63,7 +63,7 @@ public class PublicDataService {
             }
 
             // 카카오 주소 검색 API 응답 출력
-            log.info("'LAMP_BATTERY'{}, response = {}", query, response);
+            log.info("query = {}, response = {}", query, response);
 
             // insert DB
             if (equals(response.getSigungu(), sigungu)) {


### PR DESCRIPTION
## 💡 작업 내용
- [x] 공공 데이터 키워드 추출 시 특이 케이스 별도 처리
- [x] 로컬 DB 데이터 정상 삽입 확인

## 💡 자세한 설명
- 구로구 휴지통(CSV) '소재지도로명주소'에 해당 되는 컬럼 인덱스 반환
- 강북구 휴지통(API): '세부 위치'를 키워드로 추출


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #72 
