### PR TITLE
수거함 목록 조회 API 태그 전달 형식 변경

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
@@ -31,7 +31,7 @@ public class CollectingBoxResponse {
                 .id(collectingBox.getId())
                 .latitude(collectingBox.getLocation().latitude())
                 .longitude(collectingBox.getLocation().longitude())
-                .tag(collectingBox.getTag().getLabel())
+                .tag(collectingBox.getTag().name())
                 .build();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] CollectingBoxResponse의 tag 반환 형식 변경

## 💡 자세한 설명
기존 수거함 목록 조회 API에서는 응답 필드 tag가 "폐의류"처럼 라벨로 전달되었습니다.
이를 "CLOTHES"처럼 enum 자체값으로 전달되도록 수정했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #78 
