### PR TITLE
카카오 API 응답값 DB 저장시 행정동으로 저장하도록 변경

### DIFF
--- a/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
@@ -92,12 +92,13 @@ public class KakaoApiManager {
                 .build();
     }
 
-    private AddressInfoResponse getResponseWithAddress(JSONObject document, Tag tag, AddressInfoResponse.AddressInfoResponseBuilder builder) {
+    private AddressInfoResponse getResponseWithAddress(JSONObject document, Tag tag,
+                                                       AddressInfoResponse.AddressInfoResponseBuilder builder) {
         JSONObject address = document.getJSONObject("address");
         return builder.name(getDetailName(tag, ""))
                 .sido(address.getString("region_1depth_name"))
                 .sigungu(address.getString("region_2depth_name"))
-                .dong(address.getString("region_3depth_name"))
+                .dong(address.getString("region_3depth_h_name"))
                 .streetNum(address.getString("address_name"))
                 .build();
     }
@@ -110,7 +111,7 @@ public class KakaoApiManager {
         return builder
                 .sido(address.getString("region_1depth_name"))
                 .sigungu(address.getString("region_2depth_name"))
-                .dong(address.getString("region_3depth_name"))
+                .dong(address.getString("region_3depth_h_name"))
                 .name(getDetailName(tag, roadAddress.getString("building_name")))
                 .streetNum(address.getString("address_name"))
                 .roadName(roadAddress.getString("address_name"))


### PR DESCRIPTION
## 💡 작업 내용

- [x] 공공데이터 DB 저장시 행정동으로 저장하도록 변경
- [x] 로컬 DB 행정동으로 정상 저장 확인

## 💡 자세한 설명

카카오 주소 API 응답값 DB 저장시에 법정동이 아닌 행정동으로 저장하도록 변경했습니다. 


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #80 
