### PR TITLE
컨트롤러 요청 로깅을 위한 AOP 적용 

### DIFF
--- a/src/main/java/contest/collectingbox/global/common/ApiResponse.java
+++ b/src/main/java/contest/collectingbox/global/common/ApiResponse.java
@@ -1,6 +1,7 @@
 package contest.collectingbox.global.common;
 
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.OK;
@@ -26,4 +27,12 @@ public class ApiResponse<T> {
         return new ApiResponse<>(OK, SUCCESS, data);
     }
 
+    @Override
+    public String toString() {
+        return "ApiResponse{" +
+                "code=" + code +
+                ", status=" + status +
+                ", message='" + message + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
+++ b/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
@@ -33,7 +33,7 @@ public class LoggingAspect {
             log.info("[RESPONSE] {}", result);
             return result;
         }catch(Exception e){
-            log.error("[RESPONSE] exception message = {}", e.getMessage());
+            log.error("[RESPONSE] exception message = {} {}", e.getMessage(), e.getStackTrace()[0]);
             throw e;
         }
 

--- a/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
+++ b/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
@@ -1,0 +1,36 @@
+package contest.collectingbox.global.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+    @Pointcut("within(contest.collectingbox.module..*Controller)")
+    private void cut() {
+    }
+
+    @Around("cut()")
+    public Object doLogRequest(final ProceedingJoinPoint joinPoint) throws Throwable {
+        final HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+                .getRequest();
+        final String ipAddr = request.getRemoteAddr();
+        final String method = request.getMethod();
+        final String requestURI = request.getRequestURI();
+        final Object[] args = joinPoint.getArgs();
+
+        log.info("[REQUEST] {} {} {} args={}", ipAddr, method, requestURI, args);
+        Object result = joinPoint.proceed();
+        log.info("[RESPONSE] {}", result);
+        return result;
+
+    }
+}

--- a/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
+++ b/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
@@ -28,9 +28,14 @@ public class LoggingAspect {
         final Object[] args = joinPoint.getArgs();
 
         log.info("[REQUEST] {} {} {} args={}", ipAddr, method, requestURI, args);
-        Object result = joinPoint.proceed();
-        log.info("[RESPONSE] {}", result);
-        return result;
+        try{
+            Object result = joinPoint.proceed();
+            log.info("[RESPONSE] {}", result);
+            return result;
+        }catch(Exception e){
+            log.error("[RESPONSE] exception message = {}", e.getMessage());
+            throw e;
+        }
 
     }
 }

--- a/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
+++ b/src/main/java/contest/collectingbox/global/config/LoggingAspect.java
@@ -19,7 +19,7 @@ public class LoggingAspect {
     }
 
     @Around("cut()")
-    public Object doLogRequest(final ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object doLogging(final ProceedingJoinPoint joinPoint) throws Throwable {
         final HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
                 .getRequest();
         final String ipAddr = request.getRemoteAddr();

--- a/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
@@ -24,14 +24,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CollectingBoxException.class)
     public ResponseEntity<ErrorResponse> handleCollectingBoxException(CollectingBoxException e) {
         ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
-        log.error("exception message = {}", e.getMessage());
         return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> methodValidException(MethodArgumentNotValidException e) {
         String message = e.getBindingResult().getFieldError().getDefaultMessage();
-        log.error("exception message = {}", e.getMessage());
         ErrorResponse errorResponse = ErrorResponse.from(INVALID_BEAN, message);
         return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
 
@@ -40,14 +38,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     @ResponseStatus(BAD_REQUEST)
     public ErrorResponse handleMissingParams(MissingServletRequestParameterException e) {
-        log.error("exception message = {}", e.getMessage());
         return ErrorResponse.from(MISSING_REQUEST_PARAM);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     @ResponseStatus(BAD_REQUEST)
     public ErrorResponse handleMissingParams(MethodArgumentTypeMismatchException e) {
-        log.error("exception message = {}", e.getMessage());
         return ErrorResponse.from(MISMATCH_REQUEST_PARAM);
     }
 

--- a/src/main/java/contest/collectingbox/module/autocomplete/presentation/AutoCompleteController.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/presentation/AutoCompleteController.java
@@ -23,7 +23,6 @@ public class AutoCompleteController {
     @Operation(summary = "검색어 자동 완성", description = "실시간 입력값에 따라 DB에 저장된 키워드를 가져옵니다.")
     @GetMapping
     public ApiResponse<AutoCompleteResponseDto> getAutoComplete(@RequestParam String query) {
-        log.info("query = {}", query);
         AutoCompleteResponseDto response = autoCompleteService.getAutoComplete(query);
         return ApiResponse.ok(response);
     }

--- a/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/KakaoApiManager.java
@@ -31,8 +31,7 @@ public class KakaoApiManager {
 
             // 카카오 API 예외 처리
             if (response.getStatusCode() != HttpStatus.OK) {
-                log.error("Kakao API call failed status : {}", response.getStatusCode());
-                throw new RuntimeException("Kakao API fail exception");
+                throw new RuntimeException("Kakao API failed status = " + response.getStatusCode());
             }
 
             // 주소 정보 추출
@@ -47,8 +46,7 @@ public class KakaoApiManager {
             JSONObject document = documents.getJSONObject(0);
             return makeAddressDto(document, tag);
         } catch (JSONException e) {
-            log.error("Error parsing JSON from Kakao API : {}", e.getMessage());
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error parsing JSON from Kakao API", e);
         }
     }
 

--- a/src/main/java/contest/collectingbox/module/publicdata/LoadCsvPublicDataRequest.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/LoadCsvPublicDataRequest.java
@@ -2,8 +2,10 @@ package contest.collectingbox.module.publicdata;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class LoadCsvPublicDataRequest {
 
     private String sigungu;

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataExtract.java
@@ -31,8 +31,7 @@ public class PublicDataExtract {
             }
         }
 
-        log.error("Not contains anything in {}", jsonObject);
-
+        log.warn("Not contains anything in {}", jsonObject);
         return null;
     }
 
@@ -49,7 +48,7 @@ public class PublicDataExtract {
                 }
             }
         }
-        log.error("No csv column name containing keywords, columnNames = {}", (Object) columnNames);
+        log.warn("No csv column name containing keywords, columnNames = {}", (Object) columnNames);
         return -1;
     }
 

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -59,7 +59,7 @@ public class PublicDataService {
             }
 
             if (response.hasNull()) {
-                throw new RuntimeException("null");
+                throw new RuntimeException("kakao API response has null");
             }
 
             // 카카오 주소 검색 API 응답 출력
@@ -88,8 +88,7 @@ public class PublicDataService {
             }
             return saveCsvPublicData(csvReader, columnIndex, request.getSigungu(), request.getTag());
         } catch (IOException | CsvValidationException e) {
-            log.error("Fail loading CSV file: {}", e.getMessage());
-            throw new RuntimeException(e);
+            throw new RuntimeException("failed to load CSV file", e);
         }
     }
 

--- a/src/main/java/contest/collectingbox/module/review/dto/ReviewRequest.java
+++ b/src/main/java/contest/collectingbox/module/review/dto/ReviewRequest.java
@@ -10,10 +10,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 
 @Getter
 @NoArgsConstructor
+@ToString
 public class ReviewRequest {
     @Schema(description = "리뷰 내용", example = "EXIST", allowableValues = {"EXIST", "DISAPPEAR"})
     @NotNull(message = "리뷰 내용을 입력하세요.")

--- a/src/main/java/contest/collectingbox/module/review/presentation/ReviewController.java
+++ b/src/main/java/contest/collectingbox/module/review/presentation/ReviewController.java
@@ -27,7 +27,6 @@ public class ReviewController {
     @Operation(summary = "수거함 리뷰 등록", description = "수거함 ID에 해당되는 수거함에 리뷰를 등록합니다.")
     @PostMapping("/{collectionId}/review")
     public ApiResponse<Long> postReview(@RequestBody @Valid ReviewRequest dto, @PathVariable Long collectionId) {
-        log.info("collectionID for post review = {}", collectionId);
         return ApiResponse.ok(reviewService.postReview(dto, collectionId));
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] AOP를 통해 모든 컨트롤러 요청에 대한 로깅 적용

## 💡 자세한 설명
AOP(Aspect-Oriented Programming)를 이용하여 HTTP 요청과 응답을 로깅했습니다.

- contest.collectingbox.module 패키지 하위에 있는 모든 Controller 클래스의 메서드에 Advice를 적용하도록 합니다. 
- Around Advice를 통해 해당 메서드 실행 전 후에 로깅 작업을 수행합니다. 
  - HTTP 요청 정보를 추출해 로깅
  - 메서드 실행 후 반환된 결과를 로깅
- GlobalExceptionHandler의 메소드에서 중복되는 에러 로그들을 Aspect 클래스에서 처리하도록 했습니다.

로깅시 요청 dto들을 보기 좋은 형태로 출력하기 위해 dto에 toString을 재정의했습니다.
응답으로 dto의 값들을 모두 출력하는 것은 현재는 불필요하다 생각이 들어 ApiResponse의 data는 제외하고 출력하도록 toString을 재정의했습니다. 


## 📗 참고 자료
https://docs.spring.io/spring-framework/reference/core/aop/introduction-defn.html
https://shortstories.gitbooks.io/studybook/content/aop/baa8-b4e0-c6f9-c694-ccad-c5d0-b300-d574-c11c-b85c-adf8-b85c-b0a8-ae30-ae30.html
https://alexander96.tistory.com/44
https://curiousjinan.tistory.com/entry/spring-controlleradvice-logging



## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #84 
