### PR TITLE
검색어 자동완성 구와 동으로만 검색되도록 수정 

### DIFF
--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
@@ -23,7 +23,7 @@ public class AutoCompleteRepositoryImpl implements AutoCompleteRepositoryCustom 
         return queryFactory
                 .selectDistinct(new QAddressDto(location.address.sigungu, location.address.dong))
                 .from(location)
-                .where(location.address.streetNum.contains(query))
+                .where(location.address.dong.contains(query).or(location.address.sigungu.contains(query)))
                 .orderBy(location.address.sigungu.asc(), location.address.dong.asc())
                 .limit(5)
                 .fetch();


### PR DESCRIPTION
## 💡 작업 내용
- [x] 검색어 자동완성 구와 동으로만 검색되도록 수정 

## 💡 자세한 설명
'서' 또는 '서울' 검색시 서울이 포함된 주소가 검색되는 현상이 발견되어 구와 동으로만 검색되도록 수정했습니다



## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #87 
