### PR TITLE
검색어 자동완성시 dong_info 테이블에서 조회하도록 수정

### DIFF
--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import contest.collectingbox.module.autocomplete.dto.AddressDto;
 import contest.collectingbox.module.autocomplete.dto.QAddressDto;
 import contest.collectingbox.module.location.domain.QDongInfo;
-import contest.collectingbox.module.location.domain.QLocation;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 
@@ -26,6 +25,5 @@ public class AutoCompleteRepositoryImpl implements AutoCompleteRepositoryCustom 
                 .orderBy(dongInfo.sigunguNm.asc(), dongInfo.dongNm.asc())
                 .limit(5)
                 .fetch();
-
     }
 }

--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
@@ -3,6 +3,7 @@ package contest.collectingbox.module.autocomplete.domain;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import contest.collectingbox.module.autocomplete.dto.AddressDto;
 import contest.collectingbox.module.autocomplete.dto.QAddressDto;
+import contest.collectingbox.module.location.domain.QDongInfo;
 import contest.collectingbox.module.location.domain.QLocation;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -17,15 +18,14 @@ public class AutoCompleteRepositoryImpl implements AutoCompleteRepositoryCustom 
 
     @Override
     public List<AddressDto> findAutoComplete(String query) {
-
-        QLocation location = QLocation.location;
-        // SELECT DISTINCT l FROM Location l WHERE l.address.streetNum LIKE %:query% ORDER BY l.address.sigungu, l.address.dong LIMIT 5
+        QDongInfo dongInfo = QDongInfo.dongInfo;
         return queryFactory
-                .selectDistinct(new QAddressDto(location.dongInfo.sigunguNm, location.dongInfo.dongNm))
-                .from(location)
-                .where(location.dongInfo.sigunguNm.contains(query).or(location.dongInfo.dongNm.contains(query)))
-                .orderBy(location.dongInfo.sigunguNm.asc(), location.dongInfo.dongNm.asc())
+                .selectDistinct(new QAddressDto(dongInfo.sigunguNm, dongInfo.dongNm))
+                .from(dongInfo)
+                .where(dongInfo.sigunguNm.contains(query).or(dongInfo.dongNm.contains(query)))
+                .orderBy(dongInfo.sigunguNm.asc(), dongInfo.dongNm.asc())
                 .limit(5)
                 .fetch();
+
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 검색어 자동완성시 조회 테이블 수정

## 💡 자세한 설명
검색어 자동완성시 검색 단어를 dong_info 테이블에서 조회하도록 수정했습니다. 


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #89 
