### PR TITLE
행정동 테이블 분리로 인한 지역별 수거함 검색 기능 개선

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
@@ -1,5 +1,6 @@
 package contest.collectingbox.module.collectingbox.domain;
 
+import contest.collectingbox.module.location.domain.DongInfo;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,18 +17,7 @@ public interface CollectingBoxRepository extends JpaRepository<CollectingBox, Lo
                                           @Param("radius") int radius,
                                           @Param("tags") List<Tag> tags);
 
-
-    @Query(value = "select c.* from collecting_box as c " +
-            "join location as l on c.location_id = l.id " +
-            "where match (l.dong) against (:dong in natural language mode) and " +
-            "c.tag in (:tags)", nativeQuery = true)
-    List<CollectingBox> findAllByDong(@Param("dong") String dong,
-                                      @Param("tags") List<String> tags);
-
-    @Query(value = "select c.* from collecting_box as c " +
-            "join location as l on c.location_id = l.id " +
-            "where match(l.sigungu) against (:sigungu in natural language mode) and " +
-            "c.tag in (:tags)", nativeQuery = true)
-    List<CollectingBox> findAllBySigungu(@Param("sigungu") String sigungu,
-                                         @Param("tags") List<String> tags);
+    @Query("select c from CollectingBox c join c.location l where l.dongInfo = :dongInfo and c.tag in :tags")
+    List<CollectingBox> findAllByDongInfoAndTags(@Param("dongInfo") DongInfo dongInfo,
+                                                 @Param("tags") List<Tag> tags);
 }

--- a/src/main/java/contest/collectingbox/module/location/domain/DongInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/DongInfoRepository.java
@@ -1,7 +1,18 @@
 package contest.collectingbox.module.location.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface DongInfoRepository extends JpaRepository<DongInfo, Long> {
     DongInfo findBySigunguNmAndDongNm(String sigunguNm, String dongNm);
+
+    @Query("select d from DongInfo d where d.dongNm = :dongNm")
+    Optional<DongInfo> findByDongNm(@Param("dongNm") String dongNm);
+
+    @Query("select d from DongInfo d where d.sigunguNm = :sigunguNm")
+    List<DongInfo> findAllBySigunguNm(@Param("sigunguNm") String sigungNm);
 }

--- a/src/main/java/contest/collectingbox/module/location/domain/DongInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/DongInfoRepository.java
@@ -5,13 +5,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface DongInfoRepository extends JpaRepository<DongInfo, Long> {
     DongInfo findBySigunguNmAndDongNm(String sigunguNm, String dongNm);
 
     @Query("select d from DongInfo d where d.dongNm = :dongNm")
-    Optional<DongInfo> findByDongNm(@Param("dongNm") String dongNm);
+    DongInfo findByDongNm(@Param("dongNm") String dongNm);
 
     @Query("select d from DongInfo d where d.sigunguNm = :sigunguNm")
     List<DongInfo> findAllBySigunguNm(@Param("sigunguNm") String sigungNm);

--- a/src/main/java/contest/collectingbox/module/location/domain/LocationRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/LocationRepository.java
@@ -1,12 +1,6 @@
 package contest.collectingbox.module.location.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
-
-    @Query(value = "select dong from location " +
-            "where match (dong) against (:keyword in natural language mode) limit 1", nativeQuery = true)
-    String findDongByKeyword(@Param("keyword") String keyword);
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 지역별 수거함 검색 기능 개선
- [x] FullText Index 제거
- [x] API 테스트

## 💡 자세한 설명
행정동 테이블을 분리함에 따라 지역별 수거함 검색 기능도 개선했습니다.
기존 LocationRepository에서 조회하던 로직을 제거하고, DongInfoRepository에서 가져온 시군구명과 행정동명을 통해 수거함을 조회하도록 했습니다.

## 🚩 후속 작업
- Stream으로 처리한 조회 로직을 동적 쿼리와 비교 후 개선 (feat. N+1 문제)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #91 
