### PR TITLE
수거함 상세 조회 시 성능 개선

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -48,10 +48,7 @@ public class CollectingBoxService {
 
     @Transactional(readOnly = true)
     public CollectingBoxDetailResponse findBoxDetailById(Long collectionId) {
-        CollectingBox box = collectingBoxRepository.findById(collectionId)
-                .orElseThrow(() -> new CollectingBoxException(
-                        NOT_FOUND_COLLECTING_BOX));
-        return collectingBoxRepository.findDetailById(box.getId());
+        return collectingBoxRepository.findDetailById(collectionId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepositoryImpl.java
@@ -1,10 +1,12 @@
 package contest.collectingbox.module.collectingbox.domain;
 
+import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
 import static contest.collectingbox.module.collectingbox.domain.QCollectingBox.collectingBox;
 import static contest.collectingbox.module.location.domain.QLocation.location;
 import static contest.collectingbox.module.review.domain.QReview.*;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.QCollectingBoxDetailResponse;
 import contest.collectingbox.module.review.dto.ReviewResponse;
@@ -33,6 +35,10 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
                 .where(collectingBox.id.eq(id))
                 .fetchOne();
 
+        if (response == null) {
+            throw new CollectingBoxException(NOT_FOUND_COLLECTING_BOX);
+        }
+
         List<ReviewResponse> reviews = queryFactory
                 .select(new QReviewResponse(review.tag.stringValue(), review.createdAt.stringValue()))
                 .from(review)
@@ -42,7 +48,7 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
                 .fetch();
 
         response.setReviews(reviews);
-
+        
         return response;
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 수거함 상세 조회 시 불필요한 SQL 조회 제거
- [x] 수거함 상세 조회시 예외 발생 테스트 코드 추가

## 💡 자세한 설명
수거함 조회 쿼리가 두번 실행되어 한 번만 조회하도록 수정했습니다.
없는 id의 수거함 조회 시 리뷰 테이블은 조회하지 않도록 개선했습니다.

## 📗 참고 자료
https://www.inflearn.com/questions/891531/%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC-%EB%A6%AC%ED%8C%A9%ED%86%A0%EB%A7%81-%EC%A7%88%EB%AC%B8



## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #93 
