### PR TITLE
수거함 위도,경도 별 목록 조회 시 N+1 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+*.log

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/CollectingBoxRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface CollectingBoxRepository extends JpaRepository<CollectingBox, Long>, CollectingBoxRepositoryCustom {
 
-    @Query("select c from CollectingBox c join c.location l " +
+    @Query("select c from CollectingBox c join fetch c.location l " +
             "where function('st_contains', function('st_buffer', :center, :radius), l.point) and " +
             "c.tag in :tags")
     List<CollectingBox> findAllWithinArea(@Param("center") Point center,


### PR DESCRIPTION
## 💡 작업 내용
- [x] 수거함 목록 조회시 N+1 문제 fetch join 으로 해결
- [x] .log 확장자 파일 gitignore 추가

## 💡 자세한 설명
CollectingBox와 Location은 일대일 단방향 연관관계로, Location은 LAZY 로딩으로 설정되어 있습니다. 
이 때문에 수거함 조회 시 수거함 조회 쿼리 1번과 각 수거함에 연관된 위치를 가져오기 위해 N번의 추가 쿼리가 나가는 N+1문제가 발생합니다. 
따라서 fetch join 을 사용해 연관된 엔티티를 한번에 로드하도록 수정했습니다. 


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #95 
