### PR TITLE
검색어 자동완성시 구, 동 포함한 검색어 인식 구현

### DIFF
--- a/src/main/java/contest/collectingbox/module/autocomplete/application/AutoCompleteService.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/application/AutoCompleteService.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,8 +17,8 @@ public class AutoCompleteService {
     private final AutoCompleteRepository autoCompleteRepository;
 
     public AutoCompleteResponseDto getAutoComplete(String query) {
-        List<String> items = query.isEmpty() ? new ArrayList<>() :
-                autoCompleteRepository.findAutoComplete(query)
+        List<String> items =
+                autoCompleteRepository.getAutoComplete(query)
                         .stream()
                         .map(this::formatAddress)
                         .collect(Collectors.toList());

--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryCustom.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryCustom.java
@@ -4,5 +4,5 @@ import contest.collectingbox.module.autocomplete.dto.AddressDto;
 import java.util.List;
 
 public interface AutoCompleteRepositoryCustom {
-    List<AddressDto> findAutoComplete(String query);
+    List<AddressDto> getAutoComplete(String query);
 }

--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
@@ -36,7 +36,7 @@ public class AutoCompleteRepositoryImpl implements AutoCompleteRepositoryCustom 
         }
         System.out.println(2);
         return dongInfo.sigunguNm.contains(split[0])
-                .and(dongInfo.dongNm.contains(split[1]));
+                .and(dongInfo.dongNm.contains(split[split.length-1]));
 
     }
 }

--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
@@ -34,7 +34,6 @@ public class AutoCompleteRepositoryImpl implements AutoCompleteRepositoryCustom 
             return dongInfo.sigunguNm.contains(query)
                     .or(dongInfo.dongNm.contains(query));
         }
-        System.out.println(2);
         return dongInfo.sigunguNm.contains(split[0])
                 .and(dongInfo.dongNm.contains(split[split.length-1]));
 

--- a/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/domain/AutoCompleteRepositoryImpl.java
@@ -1,9 +1,11 @@
 package contest.collectingbox.module.autocomplete.domain;
 
+import static contest.collectingbox.module.location.domain.QDongInfo.dongInfo;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import contest.collectingbox.module.autocomplete.dto.AddressDto;
 import contest.collectingbox.module.autocomplete.dto.QAddressDto;
-import contest.collectingbox.module.location.domain.QDongInfo;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 
@@ -16,14 +18,25 @@ public class AutoCompleteRepositoryImpl implements AutoCompleteRepositoryCustom 
     }
 
     @Override
-    public List<AddressDto> findAutoComplete(String query) {
-        QDongInfo dongInfo = QDongInfo.dongInfo;
+    public List<AddressDto> getAutoComplete(String query) {
         return queryFactory
                 .selectDistinct(new QAddressDto(dongInfo.sigunguNm, dongInfo.dongNm))
                 .from(dongInfo)
-                .where(dongInfo.sigunguNm.contains(query).or(dongInfo.dongNm.contains(query)))
+                .where(containsQuery(query))
                 .orderBy(dongInfo.sigunguNm.asc(), dongInfo.dongNm.asc())
                 .limit(5)
                 .fetch();
+    }
+
+    private BooleanExpression containsQuery(String query) {
+        String[] split = query.split(" ");
+        if (split.length == 1) {
+            return dongInfo.sigunguNm.contains(query)
+                    .or(dongInfo.dongNm.contains(query));
+        }
+        System.out.println(2);
+        return dongInfo.sigunguNm.contains(split[0])
+                .and(dongInfo.dongNm.contains(split[1]));
+
     }
 }

--- a/src/main/java/contest/collectingbox/module/autocomplete/presentation/AutoCompleteController.java
+++ b/src/main/java/contest/collectingbox/module/autocomplete/presentation/AutoCompleteController.java
@@ -5,6 +5,7 @@ import contest.collectingbox.module.autocomplete.application.AutoCompleteService
 import contest.collectingbox.module.autocomplete.dto.AutoCompleteResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +24,10 @@ public class AutoCompleteController {
     @Operation(summary = "검색어 자동 완성", description = "실시간 입력값에 따라 DB에 저장된 키워드를 가져옵니다.")
     @GetMapping
     public ApiResponse<AutoCompleteResponseDto> getAutoComplete(@RequestParam String query) {
-        AutoCompleteResponseDto response = autoCompleteService.getAutoComplete(query);
+        AutoCompleteResponseDto response = new AutoCompleteResponseDto(new ArrayList<>());
+        if (!query.isBlank()) {
+            response = autoCompleteService.getAutoComplete(query.trim());
+        }
         return ApiResponse.ok(response);
     }
 }

--- a/src/test/java/contest/collectingbox/module/autocomplete/application/AutoCompleteServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/autocomplete/application/AutoCompleteServiceTest.java
@@ -28,7 +28,7 @@ class AutoCompleteServiceTest {
         // given
         String keyword = "상";
         // mock
-        given(autoCompleteRepository.findAutoComplete(keyword)).willReturn(
+        given(autoCompleteRepository.getAutoComplete(keyword)).willReturn(
                 List.of(new AddressDto("강동구", "상일동"), new AddressDto("노원구", "상계동")));
 
         // when


### PR DESCRIPTION
## 💡 작업 내용
- [x] 구, 동 포함한 전체 검색어 인식해 자동완성 조회하도록 구현
- [x] 검색어 인식시 공백 처리
- [x] 기존 코드 리팩토링

## 💡 자세한 설명
검색어에 공백을 포함한 경우의 여러 케이스들을 처리했습니다. 
(반환값: "강남구 개포1동")

1. 구와 동 사이 공백 하나일 경우 처리 ex) "강남구_개포1동" 
2. 구와 동 사이 공백 여러개일 경우 처리 ex) "강남구_ _ _개포1동" 
3. 맨 앞이나 맨 끝에 공백이 있을 경우 처리 ex) "_ 강남구_개포1동_" 



## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #97 
