### PR TITLE
주변 수거함 목록 조회 기능 요청 파라미터 객체화

### DIFF
--- a/src/main/java/contest/collectingbox/global/config/WebConfig.java
+++ b/src/main/java/contest/collectingbox/global/config/WebConfig.java
@@ -1,16 +1,28 @@
 package contest.collectingbox.global.config;
 
+import contest.collectingbox.global.config.web.PointArgumentResolver;
+import contest.collectingbox.global.config.web.TagsArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("*")
                 .allowedMethods("*")
                 .maxAge(3000);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new PointArgumentResolver());
+        resolvers.add(new TagsArgumentResolver());
     }
 }

--- a/src/main/java/contest/collectingbox/global/config/web/PointArgumentResolver.java
+++ b/src/main/java/contest/collectingbox/global/config/web/PointArgumentResolver.java
@@ -1,10 +1,7 @@
 package contest.collectingbox.global.config.web;
 
-import contest.collectingbox.global.exception.CollectingBoxException;
-import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.coyote.BadRequestException;
 import org.locationtech.jts.geom.Point;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.MissingServletRequestParameterException;

--- a/src/main/java/contest/collectingbox/global/config/web/PointArgumentResolver.java
+++ b/src/main/java/contest/collectingbox/global/config/web/PointArgumentResolver.java
@@ -1,0 +1,45 @@
+package contest.collectingbox.global.config.web;
+
+import contest.collectingbox.global.exception.CollectingBoxException;
+import contest.collectingbox.global.exception.ErrorCode;
+import contest.collectingbox.global.utils.GeometryUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.coyote.BadRequestException;
+import org.locationtech.jts.geom.Point;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class PointArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Point.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        if (request.getParameter("latitude") == null) {
+            throw new MissingServletRequestParameterException("latitude", "Point");
+        }
+        if (request.getParameter("longitude") == null) {
+            throw new MissingServletRequestParameterException("longitude", "Point");
+        }
+
+        double latitude;
+        double longitude;
+
+        try {
+            latitude = Double.parseDouble(request.getParameter("latitude"));
+            longitude = Double.parseDouble(request.getParameter("longitude"));
+            return GeometryUtil.toPoint(longitude, latitude);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid parameter value for latitude or longitude");
+        }
+    }
+}

--- a/src/main/java/contest/collectingbox/global/config/web/TagsArgumentResolver.java
+++ b/src/main/java/contest/collectingbox/global/config/web/TagsArgumentResolver.java
@@ -1,0 +1,30 @@
+package contest.collectingbox.global.config.web;
+
+import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TagsArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Tags.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        List<Tag> tags = Arrays.stream(request.getParameter("tags").split(","))
+                .map(Tag::valueOf)
+                .toList();
+        return new Tags(tags);
+    }
+}

--- a/src/main/java/contest/collectingbox/global/config/web/TagsArgumentResolver.java
+++ b/src/main/java/contest/collectingbox/global/config/web/TagsArgumentResolver.java
@@ -27,9 +27,13 @@ public class TagsArgumentResolver implements HandlerMethodArgumentResolver {
             throw new MissingServletRequestParameterException("tags", "Tags");
         }
 
-        List<Tag> tags = Arrays.stream(request.getParameter("tags").split(","))
-                .map(Tag::valueOf)
-                .toList();
-        return new Tags(tags);
+        try {
+            List<Tag> tags = Arrays.stream(request.getParameter("tags").split(","))
+                    .map(Tag::valueOf)
+                    .toList();
+            return new Tags(tags);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid parameter value for tags");
+        }
     }
 }

--- a/src/main/java/contest/collectingbox/global/config/web/TagsArgumentResolver.java
+++ b/src/main/java/contest/collectingbox/global/config/web/TagsArgumentResolver.java
@@ -4,6 +4,7 @@ import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.collectingbox.domain.Tags;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -22,6 +23,10 @@ public class TagsArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        if (request.getParameter("tags") == null) {
+            throw new MissingServletRequestParameterException("tags", "Tags");
+        }
+
         List<Tag> tags = Arrays.stream(request.getParameter("tags").split(","))
                 .map(Tag::valueOf)
                 .toList();

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_BEAN(BAD_REQUEST, "유효하지 않은 데이터입니다."),
     MISSING_REQUEST_PARAM(BAD_REQUEST, "'%s' 타입의 '%s' 요청 파라미터가 존재하지 않습니다."),
     MISMATCH_REQUEST_PARAM(BAD_REQUEST, "요청 파라미터가 유효하지 않습니다."),
+    ILLEGAL_ARGUMENT(BAD_REQUEST, "유효하지 않은 값입니다."),
 
     // 404
     NOT_FOUND_COLLECTING_BOX(NOT_FOUND, "해당 수거함이 존재하지 않습니다."),

--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
     NOT_SELECTED_TAG(BAD_REQUEST, "수거함 태그는 반드시 한 개 이상 설정해야 합니다."),
     INVALID_REVIEW_CONTENT(BAD_REQUEST, "올바르지 않는 리뷰 내용입니다."),
     INVALID_BEAN(BAD_REQUEST, "유효하지 않은 데이터입니다."),
-    MISSING_REQUEST_PARAM(BAD_REQUEST, "필수 요청 파라미터가 존재하지 않습니다."),
+    MISSING_REQUEST_PARAM(BAD_REQUEST, "'%s' 타입의 '%s' 요청 파라미터가 존재하지 않습니다."),
     MISMATCH_REQUEST_PARAM(BAD_REQUEST, "요청 파라미터가 유효하지 않습니다."),
 
     // 404

--- a/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
@@ -39,4 +39,10 @@ public class GlobalExceptionHandler {
     public ApiResponse<Object> handleMissingParams(MethodArgumentTypeMismatchException e) {
         return ApiResponse.error(MISMATCH_REQUEST_PARAM, MISSING_REQUEST_PARAM.getMessage());
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ApiResponse<Object> handleIllegalArgument(IllegalArgumentException e) {
+        return ApiResponse.error(ILLEGAL_ARGUMENT, e.getMessage());
+    }
 }

--- a/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/contest/collectingbox/global/exception/GlobalExceptionHandler.java
@@ -30,7 +30,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     @ResponseStatus(BAD_REQUEST)
     public ApiResponse<Object> handleMissingParams(MissingServletRequestParameterException e) {
-        return ApiResponse.error(MISSING_REQUEST_PARAM, MISSING_REQUEST_PARAM.getMessage());
+        return ApiResponse.error(MISSING_REQUEST_PARAM,
+                String.format(MISSING_REQUEST_PARAM.getMessage(), e.getParameterType(), e.getParameterName()));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -1,6 +1,5 @@
 package contest.collectingbox.module.collectingbox.application;
 
-import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
@@ -29,10 +28,8 @@ public class CollectingBoxService {
     private int radius;
 
     @Transactional(readOnly = true)
-    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final Double latitude,
-                                                                     final Double longitude,
+    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final Point center,
                                                                      final Tags tags) {
-        Point center = GeometryUtil.toPoint(longitude, latitude);
         return collectingBoxRepository.findAllWithinArea(center, radius, tags.toUnmodifiableList())
                 .stream()
                 .map(CollectingBoxResponse::fromEntity)

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/Tags.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/Tags.java
@@ -1,0 +1,22 @@
+package contest.collectingbox.module.collectingbox.domain;
+
+import contest.collectingbox.global.exception.CollectingBoxException;
+import contest.collectingbox.global.exception.ErrorCode;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Tags {
+    private final List<Tag> tags;
+
+    public Tags(List<Tag> tags) {
+        if (tags == null || tags.isEmpty()) {
+            throw new CollectingBoxException(ErrorCode.NOT_SELECTED_TAG);
+        }
+        this.tags = tags;
+    }
+
+    public List<Tag> toUnmodifiableList() {
+        return Collections.unmodifiableList(tags);
+    }
+}

--- a/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
@@ -2,13 +2,12 @@ package contest.collectingbox.module.collectingbox.presentation;
 
 import contest.collectingbox.global.common.ApiResponse;
 import contest.collectingbox.module.collectingbox.application.CollectingBoxService;
-import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,10 +22,9 @@ public class CollectingBoxController {
 
     @Operation(summary = "수거함 목록 조회", description = "위도와 경도를 기준으로 200m 반경에 위치한 수거함 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam final Double latitude,
-                                                                                  @RequestParam final Double longitude,
+    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(final Point center,
                                                                                   final Tags tags) {
-        return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(latitude, longitude, tags));
+        return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(center, tags));
     }
 
     @Operation(summary = "지역별 수거함 검색", description = "구/동 단위로 검색한 주소에 위치한 수거함 목록을 조회합니다.")

--- a/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
@@ -3,6 +3,7 @@ package contest.collectingbox.module.collectingbox.presentation;
 import contest.collectingbox.global.common.ApiResponse;
 import contest.collectingbox.module.collectingbox.application.CollectingBoxService;
 import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,14 +25,14 @@ public class CollectingBoxController {
     @GetMapping
     public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam final Double latitude,
                                                                                   @RequestParam final Double longitude,
-                                                                                  @RequestParam final List<Tag> tags) {
+                                                                                  final Tags tags) {
         return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(latitude, longitude, tags));
     }
 
     @Operation(summary = "지역별 수거함 검색", description = "구/동 단위로 검색한 주소에 위치한 수거함 목록을 조회합니다.")
     @GetMapping("/search")
     public ApiResponse<List<CollectingBoxResponse>> searchCollectingBoxes(@RequestParam final String query,
-                                                                          @RequestParam final List<Tag> tags) {
+                                                                          final Tags tags) {
         return ApiResponse.ok(collectingBoxService.searchCollectingBoxes(query, tags));
     }
 

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -5,7 +5,7 @@ import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
-import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.location.domain.Location;
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Value;
 import java.util.Collections;
 import java.util.List;
 
-import static contest.collectingbox.global.exception.ErrorCode.*;
+import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
 import static contest.collectingbox.module.collectingbox.domain.Tag.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -55,7 +55,7 @@ class CollectingBoxServiceTest {
     @DisplayName("위도와 경도를 기준으로 특정 반경에 위치한 수거함 목록 조회 성공")
     void findCollectingBoxesWithinArea_Success_withinArea() {
         // given
-        List<Tag> tags = List.of(CLOTHES, LAMP_BATTERY, MEDICINE, TRASH);
+        Tags tags = new Tags(List.of(CLOTHES, LAMP_BATTERY, MEDICINE, TRASH));
 
         CollectingBox box = CollectingBox.builder()
                 .id(1L)
@@ -64,7 +64,7 @@ class CollectingBoxServiceTest {
                 .build();
 
         // when
-        when(collectingBoxRepository.findAllWithinArea(center, radius, tags)).thenReturn(
+        when(collectingBoxRepository.findAllWithinArea(center, radius, tags.toUnmodifiableList())).thenReturn(
                 Collections.singletonList(box));
 
         List<CollectingBoxResponse> result =
@@ -79,7 +79,7 @@ class CollectingBoxServiceTest {
     void findCollectingBoxesWithinArea_Fail_ByTagIsEmpty() {
         // when, then
         Assertions.assertThatThrownBy(
-                        () -> collectingBoxService.findCollectingBoxesWithinArea(LATITUDE, LONGITUDE, List.of()))
+                        () -> collectingBoxService.findCollectingBoxesWithinArea(LATITUDE, LONGITUDE, new Tags(List.of())))
                 .isInstanceOf(CollectingBoxException.class)
                 .hasMessageContaining(ErrorCode.NOT_SELECTED_TAG.getMessage());
     }

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -32,9 +32,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CollectingBoxServiceTest {
 
-    private final double LATITUDE = 37.4888953606578;
-    private final double LONGITUDE = 126.901185398046;
-
     private Point center;
 
     @Value("${collecting-box.search.radius.meter}")
@@ -48,7 +45,7 @@ class CollectingBoxServiceTest {
 
     @BeforeEach
     void setUp() {
-        center = GeometryUtil.toPoint(LONGITUDE, LATITUDE);
+        center = GeometryUtil.toPoint(126.901185398046, 37.4888953606578);
     }
 
     @Test
@@ -68,7 +65,7 @@ class CollectingBoxServiceTest {
                 Collections.singletonList(box));
 
         List<CollectingBoxResponse> result =
-                collectingBoxService.findCollectingBoxesWithinArea(LATITUDE, LONGITUDE, tags);
+                collectingBoxService.findCollectingBoxesWithinArea(center, tags);
 
         // then
         assertThat(result.get(0).getId()).isEqualTo(box.getId());
@@ -79,7 +76,7 @@ class CollectingBoxServiceTest {
     void findCollectingBoxesWithinArea_Fail_ByTagIsEmpty() {
         // when, then
         Assertions.assertThatThrownBy(
-                        () -> collectingBoxService.findCollectingBoxesWithinArea(LATITUDE, LONGITUDE, new Tags(List.of())))
+                        () -> collectingBoxService.findCollectingBoxesWithinArea(center, new Tags(List.of())))
                 .isInstanceOf(CollectingBoxException.class)
                 .hasMessageContaining(ErrorCode.NOT_SELECTED_TAG.getMessage());
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 요청 파라미터 객체화

## 💡 자세한 설명
기존 Controller 메서드에서는 위도와 경도를 원시 타입으로 전달 받은 뒤, 서비스 계층에서 이를 Point 타입으로 변환해주었습니다. 
이를 개선하고자 ArgumentResolver를 이용해 요청 파라미터를 객체로 전달 받도록 수정했습니다.

그리고 tags에 대한 유효성 검증 로직이 서비스 계층 여러 곳에서 중복되는 것을 파악했으며, 이 또한 ArgumentResolver를 이용해 개선했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #106 
