### PR TITLE
데이터 접근 계층 외의 계층에서 Hibernate Spatial 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation "com.querydsl:querydsl-sql-spatial:${dependencyManagement.importedProperties['querydsl.version']}"
 
     // hibernate-spatial
     implementation 'org.hibernate:hibernate-spatial:6.4.4.Final'

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -2,7 +2,6 @@ package contest.collectingbox.module.collectingbox.application;
 
 import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.global.exception.ErrorCode;
-import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
@@ -11,7 +10,6 @@ import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.location.domain.DongInfo;
 import contest.collectingbox.module.location.domain.DongInfoRepository;
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,19 +28,14 @@ public class CollectingBoxService {
     private int radius;
 
     @Transactional(readOnly = true)
-    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final Double latitude,
-                                                                     final Double longitude,
+    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final double longitude,
+                                                                     final double latitude,
                                                                      final List<Tag> tags) {
         if (tags.isEmpty()) {
             throw new CollectingBoxException(ErrorCode.NOT_SELECTED_TAG);
         }
 
-        Point center = GeometryUtil.toPoint(longitude, latitude);
-
-        return collectingBoxRepository.findAllWithinArea(center, radius, tags)
-                .stream()
-                .map(CollectingBoxResponse::fromEntity)
-                .collect(Collectors.toList());
+        return collectingBoxRepository.findAllWithinArea(longitude, latitude, radius, tags);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -4,8 +4,8 @@ import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
-import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.location.domain.DongInfo;
@@ -18,8 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepository.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepository.java
@@ -3,7 +3,6 @@ package contest.collectingbox.module.collectingbox.domain.repository;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.location.domain.DongInfo;
-import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,13 +10,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface CollectingBoxRepository extends JpaRepository<CollectingBox, Long>, CollectingBoxRepositoryCustom {
-
-    @Query("select c from CollectingBox c join fetch c.location l " +
-            "where function('st_contains', function('st_buffer', :center, :radius), l.point) and " +
-            "c.tag in :tags")
-    List<CollectingBox> findAllWithinArea(@Param("center") Point center,
-                                          @Param("radius") int radius,
-                                          @Param("tags") List<Tag> tags);
 
     @Query("select c from CollectingBox c join c.location l where l.dongInfo = :dongInfo and c.tag in :tags")
     List<CollectingBox> findAllByDongInfoAndTags(@Param("dongInfo") DongInfo dongInfo,

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepository.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepository.java
@@ -1,5 +1,7 @@
-package contest.collectingbox.module.collectingbox.domain;
+package contest.collectingbox.module.collectingbox.domain.repository;
 
+import contest.collectingbox.module.collectingbox.domain.CollectingBox;
+import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.location.domain.DongInfo;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
@@ -1,7 +1,13 @@
 package contest.collectingbox.module.collectingbox.domain.repository;
 
+import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
+import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
+
+import java.util.List;
 
 public interface CollectingBoxRepositoryCustom {
     CollectingBoxDetailResponse findDetailById(Long id);
+
+    List<CollectingBoxResponse> findAllWithinArea(double longitude, double latitude, int radius, List<Tag> tags);
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
@@ -1,8 +1,7 @@
-package contest.collectingbox.module.collectingbox.domain;
+package contest.collectingbox.module.collectingbox.domain.repository;
 
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 
 public interface CollectingBoxRepositoryCustom {
     CollectingBoxDetailResponse findDetailById(Long id);
-
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
@@ -1,20 +1,22 @@
-package contest.collectingbox.module.collectingbox.domain;
-
-import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
-import static contest.collectingbox.module.collectingbox.domain.QCollectingBox.collectingBox;
-import static contest.collectingbox.module.location.domain.QLocation.location;
-import static contest.collectingbox.module.review.domain.QReview.*;
+package contest.collectingbox.module.collectingbox.domain.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.QCollectingBoxDetailResponse;
-import contest.collectingbox.module.review.dto.ReviewResponse;
 import contest.collectingbox.module.review.dto.QReviewResponse;
+import contest.collectingbox.module.review.dto.ReviewResponse;
 import jakarta.persistence.EntityManager;
+
 import java.util.List;
 
+import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
+import static contest.collectingbox.module.collectingbox.domain.QCollectingBox.collectingBox;
+import static contest.collectingbox.module.location.domain.QLocation.location;
+import static contest.collectingbox.module.review.domain.QReview.review;
+
 public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCustom {
+
     private final JPAQueryFactory queryFactory;
 
     public CollectingBoxRepositoryImpl(EntityManager em) {
@@ -23,7 +25,6 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
 
     @Override
     public CollectingBoxDetailResponse findDetailById(Long id) {
-
         CollectingBoxDetailResponse response = queryFactory.select(new QCollectingBoxDetailResponse(
                         location.point,
                         location.name, location.roadName,
@@ -48,7 +49,7 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
                 .fetch();
 
         response.setReviews(reviews);
-        
+
         return response;
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
@@ -1,6 +1,8 @@
 package contest.collectingbox.module.collectingbox.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
+import contest.collectingbox.module.collectingbox.domain.Tag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,22 +18,30 @@ public class CollectingBoxResponse {
     @Schema(description = "수거함 ID", example = "2571")
     private Long id;
 
-    @Schema(description = "위도", example = "37.4888178446615")
-    private Double latitude;
-
     @Schema(description = "경도", example = " 126.902998281977")
     private Double longitude;
 
+    @Schema(description = "위도", example = "37.4888178446615")
+    private Double latitude;
+
     @Schema(description = "태그", example = "CLOTHES",
             allowableValues = {"CLOTHES", "LAMP_BATTERY", "MEDICINE", "TRASH"})
-    private String tag;
+    private Tag tag;
+
+    @QueryProjection
+    public CollectingBoxResponse(Long id, double x, double y, Tag tag) {
+        this.id = id;
+        this.longitude = x;
+        this.latitude = y;
+        this.tag = tag;
+    }
 
     public static CollectingBoxResponse fromEntity(CollectingBox collectingBox) {
         return CollectingBoxResponse.builder()
                 .id(collectingBox.getId())
                 .latitude(collectingBox.getLocation().latitude())
                 .longitude(collectingBox.getLocation().longitude())
-                .tag(collectingBox.getTag().name())
+                .tag(collectingBox.getTag())
                 .build();
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
@@ -21,10 +21,10 @@ public class CollectingBoxController {
 
     @Operation(summary = "주변 수거함 목록 조회", description = "위도와 경도를 기준으로 주변 600m 반경에 위치한 수거함 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam final Double latitude,
-                                                                                  @RequestParam final Double longitude,
+    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam final double longitude,
+                                                                                  @RequestParam final double latitude,
                                                                                   @RequestParam final List<Tag> tags) {
-        return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(latitude, longitude, tags));
+        return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(longitude, latitude, tags));
     }
 
     @Operation(summary = "지역별 수거함 검색", description = "구/동 단위로 검색한 주소에 위치한 수거함 목록을 조회합니다.")

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -2,7 +2,7 @@ package contest.collectingbox.module.publicdata;
 
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvValidationException;
-import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
+import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.location.domain.DongInfoRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/contest/collectingbox/module/review/application/ReviewService.java
+++ b/src/main/java/contest/collectingbox/module/review/application/ReviewService.java
@@ -4,7 +4,7 @@ import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECT
 
 import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
-import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
+import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.review.domain.ReviewRepository;
 import contest.collectingbox.module.review.dto.ReviewRequest;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -4,7 +4,7 @@ import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
-import contest.collectingbox.module.collectingbox.domain.CollectingBoxRepository;
+import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -64,11 +64,11 @@ class CollectingBoxServiceTest {
                 .build();
 
         // when
-        when(collectingBoxRepository.findAllWithinArea(center, radius, tags)).thenReturn(
-                Collections.singletonList(box));
+        when(collectingBoxRepository.findAllWithinArea(LONGITUDE, LATITUDE, radius, tags))
+                .thenReturn(List.of(new CollectingBoxResponse(box.getId(), LONGITUDE, LATITUDE, CLOTHES)));
 
         List<CollectingBoxResponse> result =
-                collectingBoxService.findCollectingBoxesWithinArea(LATITUDE, LONGITUDE, tags);
+                collectingBoxService.findCollectingBoxesWithinArea(LONGITUDE, LATITUDE, tags);
 
         // then
         assertThat(result.get(0).getId()).isEqualTo(box.getId());


### PR DESCRIPTION
## 💡 작업 내용
- [x] 서비스 계층에서 Hibernate Spatial 의존성 제거
- [x] 주변 수거함 목록 조회 API의 데이터 조회 로직을 QueryDSL로 변경

## 💡 자세한 설명
### 서비스 계층에서 Hibernate Spatial 의존성 제거
기존 서비스 계층에서는 공간 데이터를 다루기 위한 Hibernate Spatial을 의존하고 있었습니다.
이는 버전이 업데이트되거나, 공간 데이터를 다루기 위해 Hibernate Spatial이 아닌 다른 라이브러리로 변경될 경우 Hibernate Spatial에 의존하고 있는 모든 클래스를 변경해야 한다는 문제가 있습니다.
따라서, Point 타입으로 변환하는 로직을 서비스 계층이 아닌 데이터 접근 계층으로 이동시켰습니다.

### QueryDSL 적용
JPQL을 사용하던 기존 방식에서 QueryDSL을 사용하는 로직으로 수정했습니다.
이를 통해 나중에 발생할 수 있을 오류를 런타임이 아닌 컴파일 시점에 파악할 수 있게 됨을 기대할 수 있습니다.
다만 `ST_X`와 `ST_Y` 함수의 경우 QueryDSL로 구현할 수 있는 방법을 찾지 못해 stringTemplate을 사용했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #109 
