### PR TITLE
Feat/111 fix point

### DIFF
--- a/src/main/java/contest/collectingbox/global/utils/GeometryUtil.java
+++ b/src/main/java/contest/collectingbox/global/utils/GeometryUtil.java
@@ -10,10 +10,8 @@ import org.locationtech.jts.geom.PrecisionModel;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GeometryUtil {
 
-    private static final int SRID = 4326;
-
     public static Point toPoint(double longitude, double latitude) {
-        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), SRID);
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel());
         return geometryFactory.createPoint(new Coordinate(longitude, latitude));
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
@@ -29,10 +29,10 @@ public class CollectingBoxResponse {
     private Tag tag;
 
     @QueryProjection
-    public CollectingBoxResponse(Long id, double x, double y, Tag tag) {
+    public CollectingBoxResponse(Long id, double longitude, double latitude, Tag tag) {
         this.id = id;
-        this.longitude = x;
-        this.latitude = y;
+        this.longitude = longitude;
+        this.latitude = latitude;
         this.tag = tag;
     }
 

--- a/src/main/java/contest/collectingbox/module/location/domain/Location.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/Location.java
@@ -24,14 +24,14 @@ public class Location extends BaseTimeEntity {
     private String roadName;
     private String streetNum;
 
-    @Column(columnDefinition = "point SRID 4326")
+    @Column(columnDefinition = "point")
     private Point point;
-
-    public double latitude() {
-        return point.getY();
-    }
 
     public double longitude() {
         return point.getX();
+    }
+
+    public double latitude() {
+        return point.getY();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] Location 클래스의 point 필드 정의에서 SRID 제거
- [x] Point 타입으로 변환 시 SRID 전달 제외
- [x] CollectingBoxResponse의 생성자 파라미터 이름 개선

## 💡 자세한 설명
데이터 저장 시 SRID 값을 전달하지 않도록 수정하여 POINT(경도 위도)가 아닌 POINT(위도 경도)로 저장되는 문제를 해결했습니다.

## 🚩 후속 작업
- 왜 이러한 문제가 발생했는지에 대한 원인 파악 및 분석

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #111 
