### PR TITLE
주변 수거함 목록 조회 오류 해결

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
@@ -36,8 +36,10 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
         return queryFactory
                 .select(new QCollectingBoxResponse(
                         collectingBox.id,
-                        Expressions.stringTemplate("function('st_x', {0})", location.point).castToNum(double.class),
-                        Expressions.stringTemplate("function('st_y', {0})", location.point).castToNum(double.class),
+                        Expressions.stringTemplate("function('st_longitude', {0})", location.point)
+                                .castToNum(double.class),
+                        Expressions.stringTemplate("function('st_latitude', {0})", location.point)
+                                .castToNum(double.class),
                         collectingBox.tag
                 ))
                 .from(collectingBox)

--- a/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/dto/CollectingBoxResponse.java
@@ -29,10 +29,10 @@ public class CollectingBoxResponse {
     private Tag tag;
 
     @QueryProjection
-    public CollectingBoxResponse(Long id, double x, double y, Tag tag) {
+    public CollectingBoxResponse(Long id, double longitude, double latitude, Tag tag) {
         this.id = id;
-        this.longitude = x;
-        this.latitude = y;
+        this.longitude = longitude;
+        this.latitude = latitude;
         this.tag = tag;
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] CollectingBoxResponse 생성자 시그니처 개선
- [x] 주변 수거함 목록 조회 로직 수정

## 💡 자세한 설명
리팩터링 도중 CollectingBoxResponse 반환 코드에 실수가 생겨 위도와 경도가 바뀌어 조회되는 문제가 발생했습니다.
이를 해결하기 위해, CollectingBoxResponse의 생성자 시그니처와 데이터 조회 로직을 수정했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #113 
