### PR TITLE
일급 컬렉션 사용하여 중복 코드 제거

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -7,6 +7,7 @@ import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailRespons
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.location.domain.DongInfo;
 import contest.collectingbox.module.location.domain.DongInfoRepository;
+import contest.collectingbox.module.location.domain.GeoPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -26,10 +27,8 @@ public class CollectingBoxService {
     private int radius;
 
     @Transactional(readOnly = true)
-    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final double longitude,
-                                                                     final double latitude,
-                                                                     final Tags tags) {
-        return collectingBoxRepository.findAllWithinArea(longitude, latitude, radius, tags);
+    public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final GeoPoint center, final Tags tags) {
+        return collectingBoxRepository.findAllWithinArea(center, radius, tags);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -1,9 +1,7 @@
 package contest.collectingbox.module.collectingbox.application;
 
-import contest.collectingbox.global.exception.CollectingBoxException;
-import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
-import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
@@ -30,11 +28,7 @@ public class CollectingBoxService {
     @Transactional(readOnly = true)
     public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final double longitude,
                                                                      final double latitude,
-                                                                     final List<Tag> tags) {
-        if (tags.isEmpty()) {
-            throw new CollectingBoxException(ErrorCode.NOT_SELECTED_TAG);
-        }
-
+                                                                     final Tags tags) {
         return collectingBoxRepository.findAllWithinArea(longitude, latitude, radius, tags);
     }
 
@@ -44,11 +38,7 @@ public class CollectingBoxService {
     }
 
     @Transactional(readOnly = true)
-    public List<CollectingBoxResponse> searchCollectingBoxes(final String query, final List<Tag> tags) {
-        if (tags.isEmpty()) {
-            throw new CollectingBoxException(ErrorCode.NOT_SELECTED_TAG);
-        }
-
+    public List<CollectingBoxResponse> searchCollectingBoxes(final String query, final Tags tags) {
         // '강남구'
         if (query.endsWith("구")) {
             return searchBySigunguNm(query, tags);
@@ -65,16 +55,17 @@ public class CollectingBoxService {
         return searchByDongNm(splitQuery[1], tags);
     }
 
-    private List<CollectingBoxResponse> searchBySigunguNm(String query, List<Tag> tags) {
+    private List<CollectingBoxResponse> searchBySigunguNm(String query, Tags tags) {
         return dongInfoRepository.findAllBySigunguNm(query).stream()
-                .flatMap(dongInfo -> collectingBoxRepository.findAllByDongInfoAndTags(dongInfo, tags).stream())
+                .flatMap(dongInfo ->
+                        collectingBoxRepository.findAllByDongInfoAndTags(dongInfo, tags.getTags()).stream())
                 .map(CollectingBoxResponse::fromEntity)
                 .collect(Collectors.toList());
     }
 
-    private List<CollectingBoxResponse> searchByDongNm(String dongNm, List<Tag> tags) {
+    private List<CollectingBoxResponse> searchByDongNm(String dongNm, Tags tags) {
         DongInfo dongInfo = dongInfoRepository.findByDongNm(dongNm);
-        List<CollectingBox> boxes = collectingBoxRepository.findAllByDongInfoAndTags(dongInfo, tags);
+        List<CollectingBox> boxes = collectingBoxRepository.findAllByDongInfoAndTags(dongInfo, tags.getTags());
         return boxes.stream()
                 .map(CollectingBoxResponse::fromEntity)
                 .collect(Collectors.toList());

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/Tags.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/Tags.java
@@ -1,0 +1,22 @@
+package contest.collectingbox.module.collectingbox.domain;
+
+import contest.collectingbox.global.exception.CollectingBoxException;
+
+import java.util.List;
+
+import static contest.collectingbox.global.exception.ErrorCode.NOT_SELECTED_TAG;
+
+public class Tags {
+    private final List<Tag> tags;
+
+    public Tags(List<Tag> tags) {
+        if (tags == null || tags.isEmpty()) {
+            throw new CollectingBoxException(NOT_SELECTED_TAG);
+        }
+        this.tags = tags;
+    }
+
+    public List<Tag> getTags() {
+        return List.copyOf(tags);
+    }
+}

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
@@ -3,11 +3,12 @@ package contest.collectingbox.module.collectingbox.domain.repository;
 import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
+import contest.collectingbox.module.location.domain.GeoPoint;
 
 import java.util.List;
 
 public interface CollectingBoxRepositoryCustom {
     CollectingBoxDetailResponse findDetailById(Long id);
 
-    List<CollectingBoxResponse> findAllWithinArea(double longitude, double latitude, int radius, Tags tags);
+    List<CollectingBoxResponse> findAllWithinArea(GeoPoint center, int radius, Tags tags);
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
@@ -1,6 +1,6 @@
 package contest.collectingbox.module.collectingbox.domain.repository;
 
-import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 
@@ -9,5 +9,5 @@ import java.util.List;
 public interface CollectingBoxRepositoryCustom {
     CollectingBoxDetailResponse findDetailById(Long id);
 
-    List<CollectingBoxResponse> findAllWithinArea(double longitude, double latitude, int radius, List<Tag> tags);
+    List<CollectingBoxResponse> findAllWithinArea(double longitude, double latitude, int radius, Tags tags);
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
@@ -10,6 +10,7 @@ import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailRespons
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.collectingbox.dto.QCollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.QCollectingBoxResponse;
+import contest.collectingbox.module.location.domain.GeoPoint;
 import contest.collectingbox.module.review.dto.QReviewResponse;
 import contest.collectingbox.module.review.dto.ReviewResponse;
 import jakarta.persistence.EntityManager;
@@ -31,8 +32,8 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
     }
 
     @Override
-    public List<CollectingBoxResponse> findAllWithinArea(double longitude, double latitude, int radius, Tags tags) {
-        Point centerPoint = GeometryUtil.toPoint(longitude, latitude);
+    public List<CollectingBoxResponse> findAllWithinArea(GeoPoint center, int radius, Tags tags) {
+        Point centerPoint = GeometryUtil.toPoint(center.getLongitude(), center.getLatitude());
         return queryFactory
                 .select(new QCollectingBoxResponse(
                         collectingBox.id,

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
@@ -5,7 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.querydsl.spatial.locationtech.jts.JTSGeometryExpressions;
 import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.global.utils.GeometryUtil;
-import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.collectingbox.dto.QCollectingBoxDetailResponse;
@@ -31,7 +31,7 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
     }
 
     @Override
-    public List<CollectingBoxResponse> findAllWithinArea(double longitude, double latitude, int radius, List<Tag> tags) {
+    public List<CollectingBoxResponse> findAllWithinArea(double longitude, double latitude, int radius, Tags tags) {
         Point centerPoint = GeometryUtil.toPoint(longitude, latitude);
         return queryFactory
                 .select(new QCollectingBoxResponse(
@@ -45,7 +45,7 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
                 .from(collectingBox)
                 .join(collectingBox.location, location)
                 .where(JTSGeometryExpressions.asJTSGeometry(centerPoint).buffer(radius).contains(location.point),
-                        collectingBox.tag.in(tags))
+                        collectingBox.tag.in(tags.getTags()))
                 .fetch();
     }
 

--- a/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
@@ -5,6 +5,7 @@ import contest.collectingbox.module.collectingbox.application.CollectingBoxServi
 import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
+import contest.collectingbox.module.location.domain.GeoPoint;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -21,10 +22,9 @@ public class CollectingBoxController {
 
     @Operation(summary = "주변 수거함 목록 조회", description = "위도와 경도를 기준으로 주변 600m 반경에 위치한 수거함 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam final double longitude,
-                                                                                  @RequestParam final double latitude,
+    public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(final GeoPoint center,
                                                                                   final Tags tags) {
-        return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(longitude, latitude, tags));
+        return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(center, tags));
     }
 
     @Operation(summary = "지역별 수거함 검색", description = "구/동 단위로 검색한 주소에 위치한 수거함 목록을 조회합니다.")

--- a/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/presentation/CollectingBoxController.java
@@ -2,7 +2,7 @@ package contest.collectingbox.module.collectingbox.presentation;
 
 import contest.collectingbox.global.common.ApiResponse;
 import contest.collectingbox.module.collectingbox.application.CollectingBoxService;
-import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,14 +23,14 @@ public class CollectingBoxController {
     @GetMapping
     public ApiResponse<List<CollectingBoxResponse>> findCollectingBoxesWithinArea(@RequestParam final double longitude,
                                                                                   @RequestParam final double latitude,
-                                                                                  @RequestParam final List<Tag> tags) {
+                                                                                  final Tags tags) {
         return ApiResponse.ok(collectingBoxService.findCollectingBoxesWithinArea(longitude, latitude, tags));
     }
 
     @Operation(summary = "지역별 수거함 검색", description = "구/동 단위로 검색한 주소에 위치한 수거함 목록을 조회합니다.")
     @GetMapping("/search")
     public ApiResponse<List<CollectingBoxResponse>> searchCollectingBoxes(@RequestParam final String query,
-                                                                          @RequestParam final List<Tag> tags) {
+                                                                          final Tags tags) {
         return ApiResponse.ok(collectingBoxService.searchCollectingBoxes(query, tags));
     }
 

--- a/src/main/java/contest/collectingbox/module/location/domain/GeoPoint.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/GeoPoint.java
@@ -1,0 +1,26 @@
+package contest.collectingbox.module.location.domain;
+
+import contest.collectingbox.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class GeoPoint {
+    private final double longitude;
+    private final double latitude;
+
+    public GeoPoint(double longitude, double latitude) {
+        if (invalidLongitude(longitude) || invalidLatitude(latitude)) {
+            throw new IllegalArgumentException("Invalid parameter value for longitude or latitude");
+        }
+        this.longitude = longitude;
+        this.latitude = latitude;
+    }
+
+    private boolean invalidLongitude(double longitude) {
+        return longitude < -180 || longitude > 180;
+    }
+
+    private boolean invalidLatitude(double latitude) {
+        return latitude < -90 || latitude > 90;
+    }
+}

--- a/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
+++ b/src/test/java/contest/collectingbox/module/collectingbox/application/CollectingBoxServiceTest.java
@@ -4,10 +4,12 @@ import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.global.exception.ErrorCode;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
-import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.Tags;
+import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
+import contest.collectingbox.module.location.domain.GeoPoint;
 import contest.collectingbox.module.location.domain.Location;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,10 +22,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 
-import java.util.Collections;
 import java.util.List;
 
-import static contest.collectingbox.global.exception.ErrorCode.*;
+import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
 import static contest.collectingbox.module.collectingbox.domain.Tag.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -32,13 +33,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CollectingBoxServiceTest {
 
-    private final double LATITUDE = 37.4888953606578;
-    private final double LONGITUDE = 126.901185398046;
-
-    private Point center;
-
     @Value("${collecting-box.search.radius.meter}")
     private int radius;
+
+    private GeoPoint center;
 
     @InjectMocks
     private CollectingBoxService collectingBoxService;
@@ -48,14 +46,14 @@ class CollectingBoxServiceTest {
 
     @BeforeEach
     void setUp() {
-        center = GeometryUtil.toPoint(LONGITUDE, LATITUDE);
+        center = new GeoPoint(126.901185398046, 37.4888953606578);
     }
 
     @Test
     @DisplayName("위도와 경도를 기준으로 특정 반경에 위치한 수거함 목록 조회 성공")
     void findCollectingBoxesWithinArea_Success_withinArea() {
         // given
-        List<Tag> tags = List.of(CLOTHES, LAMP_BATTERY, MEDICINE, TRASH);
+        Tags tags = new Tags(List.of(CLOTHES, LAMP_BATTERY, MEDICINE, TRASH));
 
         CollectingBox box = CollectingBox.builder()
                 .id(1L)
@@ -64,11 +62,12 @@ class CollectingBoxServiceTest {
                 .build();
 
         // when
-        when(collectingBoxRepository.findAllWithinArea(LONGITUDE, LATITUDE, radius, tags))
-                .thenReturn(List.of(new CollectingBoxResponse(box.getId(), LONGITUDE, LATITUDE, CLOTHES)));
+        when(collectingBoxRepository.findAllWithinArea(center, radius, tags))
+                .thenReturn(List.of(
+                        new CollectingBoxResponse(box.getId(), center.getLongitude(), center.getLatitude(), CLOTHES)));
 
         List<CollectingBoxResponse> result =
-                collectingBoxService.findCollectingBoxesWithinArea(LONGITUDE, LATITUDE, tags);
+                collectingBoxService.findCollectingBoxesWithinArea(center, tags);
 
         // then
         assertThat(result.get(0).getId()).isEqualTo(box.getId());
@@ -79,7 +78,7 @@ class CollectingBoxServiceTest {
     void findCollectingBoxesWithinArea_Fail_ByTagIsEmpty() {
         // when, then
         Assertions.assertThatThrownBy(
-                        () -> collectingBoxService.findCollectingBoxesWithinArea(LATITUDE, LONGITUDE, List.of()))
+                        () -> collectingBoxService.findCollectingBoxesWithinArea(center, new Tags(List.of())))
                 .isInstanceOf(CollectingBoxException.class)
                 .hasMessageContaining(ErrorCode.NOT_SELECTED_TAG.getMessage());
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 일급 컬렉션 Tags를 통해 중복 코드 제거
- [x] 위도와 경도를 래핑하여 코드 가독성 개선

## 💡 자세한 설명
### 일급 컬렉션 적용
```java
@Transactional(readOnly = true)
public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final double longitude,
                                                                 final double latitude,
                                                                 final List<Tag> tags) {
    if (tags.isEmpty()) {
        throw new CollectingBoxException(ErrorCode.NOT_SELECTED_TAG);
    }
    return collectingBoxRepository.findAllWithinArea(longitude, latitude, radius, tags);
}
```
위와 같이 수거함 태그의 유효성을 검증하는 로직이 서비스 계층 여러 메서드에 존재했습니다. 
따라서 `List<Tag>` 타입의 변수를 가지는 일급 컬렉션 `Tags`를 만들고, 유효성 검증 로직을 해당 객체에 위임했습니다.
```java
public class Tags {
    private final List<Tag> tags;

    public Tags(List<Tag> tags) {
        if (tags == null || tags.isEmpty()) {
            throw new CollectingBoxException(NOT_SELECTED_TAG);
        }
        this.tags = tags;
    }

    public List<Tag> getTags() {
        return List.copyOf(tags);
    }
}

```
이를 통해 서비스 계층의 중복 코드를 제거할 수 있었습니다.

### 위도, 경도 래핑
기존 모든 계층의 메서드에서는 다음과 같이 위도와 경도를 전달 받고 있었습니다.
```java
@Transactional(readOnly = true)
public List<CollectingBoxResponse> findCollectingBoxesWithinArea(final double longitude,
                                                                 final double latitude,
                                                                 final Tags tags) {
    return collectingBoxRepository.findAllWithinArea(longitude, latitude, radius, tags);
}
```
이렇게 위도와 경도를 전달 받게 되면, 파라미터 순서를 실수할 위험이 있습니다.
그래서 GeoPoint라는 클래스로 래핑하였습니다.
```java
public class GeoPoint {
    private final double longitude;
    private final double latitude;

    public GeoPoint(double longitude, double latitude) {
        if (invalidLongitude(longitude) || invalidLatitude(latitude)) {
            throw new IllegalArgumentException("Invalid parameter value for longitude or latitude");
        }
        this.longitude = longitude;
        this.latitude = latitude;
    }

    private boolean invalidLongitude(double longitude) {
        return longitude < -180 || longitude > 180;
    }

    private boolean invalidLatitude(double latitude) {
        return latitude < -90 || latitude > 90;
    }
}

```
이를 통해 순서를 틀릴 수 있는 문제를 방지할 수 있으며, 코드의 가독성도 향상시킬 수 있게 되었습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #115 
