### PR TITLE
지역별 수거함 검색 기능의 데이터 조회 로직을 QueryDSL로 마이그레이션

### DIFF
--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -6,7 +6,7 @@ import contest.collectingbox.module.collectingbox.domain.repository.CollectingBo
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
 import contest.collectingbox.module.location.domain.DongInfo;
-import contest.collectingbox.module.location.domain.DongInfoRepository;
+import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import contest.collectingbox.module.location.domain.GeoPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -1,20 +1,17 @@
 package contest.collectingbox.module.collectingbox.application;
 
-import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.Tags;
 import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxDetailResponse;
 import contest.collectingbox.module.collectingbox.dto.CollectingBoxResponse;
-import contest.collectingbox.module.location.domain.DongInfo;
-import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import contest.collectingbox.module.location.domain.GeoPoint;
+import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -58,11 +55,7 @@ public class CollectingBoxService {
         return collectingBoxRepository.searchBySigunguNm(query, tags);
     }
 
-    private List<CollectingBoxResponse> searchByDongNm(String dongNm, Tags tags) {
-        DongInfo dongInfo = dongInfoRepository.findByDongNm(dongNm);
-        List<CollectingBox> boxes = collectingBoxRepository.findAllByDongInfoAndTags(dongInfo, tags.getTags());
-        return boxes.stream()
-                .map(CollectingBoxResponse::fromEntity)
-                .collect(Collectors.toList());
+    private List<CollectingBoxResponse> searchByDongNm(String query, Tags tags) {
+        return collectingBoxRepository.searchByDongNm(query, tags);
     }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/application/CollectingBoxService.java
@@ -55,11 +55,7 @@ public class CollectingBoxService {
     }
 
     private List<CollectingBoxResponse> searchBySigunguNm(String query, Tags tags) {
-        return dongInfoRepository.findAllBySigunguNm(query).stream()
-                .flatMap(dongInfo ->
-                        collectingBoxRepository.findAllByDongInfoAndTags(dongInfo, tags.getTags()).stream())
-                .map(CollectingBoxResponse::fromEntity)
-                .collect(Collectors.toList());
+        return collectingBoxRepository.searchBySigunguNm(query, tags);
     }
 
     private List<CollectingBoxResponse> searchByDongNm(String dongNm, Tags tags) {

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface CollectingBoxRepositoryCustom {
     CollectingBoxDetailResponse findDetailById(Long id);
 
     List<CollectingBoxResponse> findAllWithinArea(GeoPoint center, int radius, Tags tags);
+
+    List<CollectingBoxResponse> searchBySigunguNm(String query, Tags tags);
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface CollectingBoxRepositoryCustom {
     List<CollectingBoxResponse> findAllWithinArea(GeoPoint center, int radius, Tags tags);
 
     List<CollectingBoxResponse> searchBySigunguNm(String query, Tags tags);
+
+    List<CollectingBoxResponse> searchByDongNm(String query, Tags tags);
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
@@ -110,4 +110,25 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
                                 .where(dongInfo.sigunguNm.eq(query))))
                 .fetch();
     }
+
+    @Override
+    public List<CollectingBoxResponse> searchByDongNm(String query, Tags tags) {
+        return queryFactory
+                .select(new QCollectingBoxResponse(
+                        collectingBox.id,
+                        Expressions.stringTemplate("function('st_longitude', {0})", location.point)
+                                .castToNum(double.class),
+                        Expressions.stringTemplate("function('st_latitude', {0})", location.point)
+                                .castToNum(double.class),
+                        collectingBox.tag
+                ))
+                .from(collectingBox)
+                .join(collectingBox.location, location)
+                .where(location.dongInfo.dongCd.in(
+                        JPAExpressions
+                                .select(dongInfo.dongCd)
+                                .from(dongInfo)
+                                .where(dongInfo.dongNm.eq(query))))
+                .fetch();
+    }
 }

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepositoryImpl.java
@@ -2,6 +2,7 @@ package contest.collectingbox.module.collectingbox.domain.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.global.utils.GeometryUtil;
@@ -20,6 +21,7 @@ import java.util.List;
 
 import static contest.collectingbox.global.exception.ErrorCode.NOT_FOUND_COLLECTING_BOX;
 import static contest.collectingbox.module.collectingbox.domain.QCollectingBox.collectingBox;
+import static contest.collectingbox.module.location.domain.QDongInfo.dongInfo;
 import static contest.collectingbox.module.location.domain.QLocation.location;
 import static contest.collectingbox.module.review.domain.QReview.review;
 
@@ -86,5 +88,26 @@ public class CollectingBoxRepositoryImpl implements CollectingBoxRepositoryCusto
         response.setReviews(reviews);
 
         return response;
+    }
+
+    @Override
+    public List<CollectingBoxResponse> searchBySigunguNm(String query, Tags tags) {
+        return queryFactory
+                .select(new QCollectingBoxResponse(
+                        collectingBox.id,
+                        Expressions.stringTemplate("function('st_longitude', {0})", location.point)
+                                .castToNum(double.class),
+                        Expressions.stringTemplate("function('st_latitude', {0})", location.point)
+                                .castToNum(double.class),
+                        collectingBox.tag
+                ))
+                .from(collectingBox)
+                .join(collectingBox.location, location)
+                .where(location.dongInfo.dongCd.in(
+                        JPAExpressions
+                                .select(dongInfo.dongCd)
+                                .from(dongInfo)
+                                .where(dongInfo.sigunguNm.eq(query))))
+                .fetch();
     }
 }

--- a/src/main/java/contest/collectingbox/module/location/domain/repository/DongInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/repository/DongInfoRepository.java
@@ -2,12 +2,7 @@ package contest.collectingbox.module.location.domain.repository;
 
 import contest.collectingbox.module.location.domain.DongInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface DongInfoRepository extends JpaRepository<DongInfo, Long> {
     DongInfo findBySigunguNmAndDongNm(String sigunguNm, String dongNm);
-
-    @Query("select d from DongInfo d where d.dongNm = :dongNm")
-    DongInfo findByDongNm(@Param("dongNm") String dongNm);
 }

--- a/src/main/java/contest/collectingbox/module/location/domain/repository/DongInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/repository/DongInfoRepository.java
@@ -5,14 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface DongInfoRepository extends JpaRepository<DongInfo, Long> {
     DongInfo findBySigunguNmAndDongNm(String sigunguNm, String dongNm);
 
     @Query("select d from DongInfo d where d.dongNm = :dongNm")
     DongInfo findByDongNm(@Param("dongNm") String dongNm);
-
-    @Query("select d from DongInfo d where d.sigunguNm = :sigunguNm")
-    List<DongInfo> findAllBySigunguNm(@Param("sigunguNm") String sigungNm);
 }

--- a/src/main/java/contest/collectingbox/module/location/domain/repository/DongInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/repository/DongInfoRepository.java
@@ -1,5 +1,6 @@
-package contest.collectingbox.module.location.domain;
+package contest.collectingbox.module.location.domain.repository;
 
+import contest.collectingbox.module.location.domain.DongInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/contest/collectingbox/module/location/domain/repository/LocationRepository.java
+++ b/src/main/java/contest/collectingbox/module/location/domain/repository/LocationRepository.java
@@ -1,5 +1,6 @@
-package contest.collectingbox.module.location.domain;
+package contest.collectingbox.module.location.domain.repository;
 
+import contest.collectingbox.module.location.domain.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {

--- a/src/main/java/contest/collectingbox/module/publicdata/AddressInfoDto.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/AddressInfoDto.java
@@ -3,7 +3,7 @@ package contest.collectingbox.module.publicdata;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.Tag;
-import contest.collectingbox.module.location.domain.DongInfoRepository;
+import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import contest.collectingbox.module.location.domain.Location;
 import lombok.*;
 

--- a/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/PublicDataService.java
@@ -4,7 +4,7 @@ import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvValidationException;
 import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
-import contest.collectingbox.module.location.domain.DongInfoRepository;
+import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;


### PR DESCRIPTION
## 💡 작업 내용
- [x] repository 클래스들 패키지 위치 변경
- [x] searchBySigunguNm 메서드의 데이터 조회 로직을 QueryDSL로 마이그레이션
- [x]  searchByDongNm 메서드의 데이터 조회 로직을 QueryDSL로 마이그레이션

## 💡 자세한 설명
JPQL을 사용하던 지역별 수거함 검색 기능 코드를 QueryDSL로 변경했습니다.
이를 통해 복잡한 코드가 간소화 되었으며, SQL문을 문자열로 작성할 필요가 없어져 후에 발생 가능한 오류를 방지할 수 있게 되었습니다.

추가로 기존 지역별 수거함 검색 기능의 경우, 수많은 쿼리가 생성되는 문제를 확인했습니다. 따라서 서브쿼리를 통해 이를 해결했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #122 
