### PR TITLE
공공데이터 저장 기능의 코드 구조 개선

### DIFF
--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -4,8 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
@@ -25,11 +24,10 @@ public enum ErrorCode {
     NOT_FOUND_COLLECTING_BOX(NOT_FOUND, "해당 수거함이 존재하지 않습니다."),
 
     // 임시
-    NOT_FOUND_TAG(NOT_FOUND, "해당 이름과 일치하는 수거함 태그가 없습니다.");
-
-    // 409
+    NOT_FOUND_TAG(NOT_FOUND, "해당 이름과 일치하는 수거함 태그가 없습니다."),
 
     // 500
+    UNEXPECTED_ERROR_EXTERNAL_API(INTERNAL_SERVER_ERROR, "외부 API 호출 시 알 수 없는 예외가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepository.java
+++ b/src/main/java/contest/collectingbox/module/collectingbox/domain/repository/CollectingBoxRepository.java
@@ -1,17 +1,7 @@
 package contest.collectingbox.module.collectingbox.domain.repository;
 
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
-import contest.collectingbox.module.collectingbox.domain.Tag;
-import contest.collectingbox.module.location.domain.DongInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface CollectingBoxRepository extends JpaRepository<CollectingBox, Long>, CollectingBoxRepositoryCustom {
-
-    @Query("select c from CollectingBox c join c.location l where l.dongInfo = :dongInfo and c.tag in :tags")
-    List<CollectingBox> findAllByDongInfoAndTags(@Param("dongInfo") DongInfo dongInfo,
-                                                 @Param("tags") List<Tag> tags);
 }

--- a/src/main/java/contest/collectingbox/module/publicdata/application/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/application/PublicDataService.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -37,6 +38,7 @@ public class PublicDataService {
     private final CollectingBoxRepository collectingBoxRepository;
     private final DongInfoRepository dongInfoRepository;
 
+    @Transactional
     public void savePublicDataApiInfo(List<SavePublicDataApiInfoRequest> requests) {
         publicDataApiInfoRepository.saveAll(getEntities(requests));
     }
@@ -47,6 +49,7 @@ public class PublicDataService {
                 .toList();
     }
 
+    @Transactional
     public long loadPublicData(JSONObject jsonObject, String sigungu, Tag tag) {
         long loadedDataCount = 0;
         JSONArray jsonArray = (JSONArray) jsonObject.get("data");
@@ -88,6 +91,7 @@ public class PublicDataService {
         return loadedDataCount;
     }
 
+    @Transactional
     public long loadCsvPublicData(LoadCsvPublicDataRequest request) {
         String fileName = CSV_FILE_PATH + request.getFileName();
         try {

--- a/src/main/java/contest/collectingbox/module/publicdata/application/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/application/PublicDataService.java
@@ -2,12 +2,13 @@ package contest.collectingbox.module.publicdata.application;
 
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvValidationException;
-import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import contest.collectingbox.module.publicdata.domain.KakaoApiManager;
-import contest.collectingbox.module.publicdata.domain.PublicDataApiInfoRepository;
+import contest.collectingbox.module.publicdata.domain.PublicDataApiInfo;
 import contest.collectingbox.module.publicdata.domain.PublicDataExtract;
+import contest.collectingbox.module.publicdata.domain.repository.PublicDataApiInfoRepository;
 import contest.collectingbox.module.publicdata.dto.AddressInfoDto;
 import contest.collectingbox.module.publicdata.dto.LoadCsvPublicDataRequest;
 import contest.collectingbox.module.publicdata.dto.SavePublicDataApiInfoRequest;
@@ -37,9 +38,13 @@ public class PublicDataService {
     private final DongInfoRepository dongInfoRepository;
 
     public void savePublicDataApiInfo(List<SavePublicDataApiInfoRequest> requests) {
-        for (SavePublicDataApiInfoRequest request : requests) {
-            publicDataApiInfoRepository.save(request.toEntity());
-        }
+        publicDataApiInfoRepository.saveAll(getEntities(requests));
+    }
+
+    private List<PublicDataApiInfo> getEntities(List<SavePublicDataApiInfoRequest> requests) {
+        return requests.stream()
+                .map(SavePublicDataApiInfoRequest::toEntity)
+                .toList();
     }
 
     public long loadPublicData(JSONObject jsonObject, String sigungu, Tag tag) {

--- a/src/main/java/contest/collectingbox/module/publicdata/application/PublicDataService.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/application/PublicDataService.java
@@ -1,10 +1,16 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.application;
 
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvValidationException;
 import contest.collectingbox.module.collectingbox.domain.repository.CollectingBoxRepository;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
+import contest.collectingbox.module.publicdata.domain.KakaoApiManager;
+import contest.collectingbox.module.publicdata.domain.PublicDataApiInfoRepository;
+import contest.collectingbox.module.publicdata.domain.PublicDataExtract;
+import contest.collectingbox.module.publicdata.dto.AddressInfoDto;
+import contest.collectingbox.module.publicdata.dto.LoadCsvPublicDataRequest;
+import contest.collectingbox.module.publicdata.dto.SavePublicDataApiInfoRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/AddressInfoMapper.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/AddressInfoMapper.java
@@ -1,11 +1,12 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.domain;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.publicdata.dto.AddressInfoDto;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.json.JSONObject;
 
-import static contest.collectingbox.module.publicdata.AddressInfoDto.*;
+import static contest.collectingbox.module.publicdata.dto.AddressInfoDto.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AddressInfoMapper {

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/KakaoApiManager.java
@@ -1,6 +1,7 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.domain;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.publicdata.dto.AddressInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/OpenDataApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/OpenDataApiManager.java
@@ -1,0 +1,46 @@
+package contest.collectingbox.module.publicdata.domain;
+
+import contest.collectingbox.global.exception.CollectingBoxException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import static contest.collectingbox.global.exception.ErrorCode.UNEXPECTED_ERROR_EXTERNAL_API;
+
+@Component
+public class OpenDataApiManager {
+
+    private static final String API_URL = "https://api.odcloud.kr/api%s?serviceKey=%s&perPage=%d";
+
+    @Value("${public-data.api.key}")
+    private String apiKey;
+
+    public int fetchTotalCount(String callAddress) {
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.getForEntity(getUrl(callAddress, 1), String.class);
+        if (isError(response)) {
+            throw new CollectingBoxException(UNEXPECTED_ERROR_EXTERNAL_API);
+        }
+        return new JSONObject(response.getBody()).getInt("totalCount");
+    }
+
+    public JSONArray fetchOpenData(String callAddress, int perPage) {
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.getForEntity(getUrl(callAddress, perPage), String.class);
+        if (isError(response)) {
+            throw new CollectingBoxException(UNEXPECTED_ERROR_EXTERNAL_API);
+        }
+        return new JSONObject(response.getBody()).getJSONArray("data");
+    }
+
+    private String getUrl(String callAddress, int perPage) {
+        return String.format(API_URL, callAddress, apiKey, perPage);
+    }
+
+    private boolean isError(ResponseEntity<String> response) {
+        return response.getStatusCode().isError();
+    }
+}

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataApiInfo.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataApiInfo.java
@@ -1,4 +1,4 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.domain;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import jakarta.persistence.*;

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataApiInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataApiInfoRepository.java
@@ -1,4 +1,4 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataApiInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataApiInfoRepository.java
@@ -1,6 +1,5 @@
-package contest.collectingbox.module.publicdata.domain.repository;
+package contest.collectingbox.module.publicdata.domain;
 
-import contest.collectingbox.module.publicdata.domain.PublicDataApiInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PublicDataApiInfoRepository extends JpaRepository<PublicDataApiInfo, Long> {

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataExtract.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/PublicDataExtract.java
@@ -1,4 +1,4 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.domain;
 
 import static contest.collectingbox.module.collectingbox.domain.Tag.*;
 

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/repository/PublicDataApiInfoRepository.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/repository/PublicDataApiInfoRepository.java
@@ -1,5 +1,6 @@
-package contest.collectingbox.module.publicdata.domain;
+package contest.collectingbox.module.publicdata.domain.repository;
 
+import contest.collectingbox.module.publicdata.domain.PublicDataApiInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PublicDataApiInfoRepository extends JpaRepository<PublicDataApiInfo, Long> {

--- a/src/main/java/contest/collectingbox/module/publicdata/dto/AddressInfoDto.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/dto/AddressInfoDto.java
@@ -1,4 +1,4 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.dto;
 
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;

--- a/src/main/java/contest/collectingbox/module/publicdata/dto/AddressInfoDto.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/dto/AddressInfoDto.java
@@ -3,10 +3,9 @@ package contest.collectingbox.module.publicdata.dto;
 import contest.collectingbox.global.utils.GeometryUtil;
 import contest.collectingbox.module.collectingbox.domain.CollectingBox;
 import contest.collectingbox.module.collectingbox.domain.Tag;
-import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import contest.collectingbox.module.location.domain.Location;
+import contest.collectingbox.module.location.domain.repository.DongInfoRepository;
 import lombok.*;
-
 
 @ToString
 @Getter
@@ -38,6 +37,10 @@ public class AddressInfoDto {
         return sido.isEmpty() || sigungu.isEmpty() || dong.isEmpty() ||
                 (name.isEmpty() && roadName.isEmpty() && streetNum.isEmpty())
                 || tag.name().isEmpty();
+    }
+
+    public boolean isSigunguEquals(String sigungu) {
+        return this.sigungu.equals(sigungu);
     }
 
     public CollectingBox toCollectingBox(DongInfoRepository repository) {

--- a/src/main/java/contest/collectingbox/module/publicdata/dto/LoadCsvPublicDataRequest.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/dto/LoadCsvPublicDataRequest.java
@@ -1,4 +1,4 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.dto;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import lombok.Getter;

--- a/src/main/java/contest/collectingbox/module/publicdata/dto/LoadPublicDataRequest.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/dto/LoadPublicDataRequest.java
@@ -1,4 +1,4 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.dto;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import lombok.Data;

--- a/src/main/java/contest/collectingbox/module/publicdata/dto/SavePublicDataApiInfoRequest.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/dto/SavePublicDataApiInfoRequest.java
@@ -1,6 +1,7 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.dto;
 
 import contest.collectingbox.module.collectingbox.domain.Tag;
+import contest.collectingbox.module.publicdata.domain.PublicDataApiInfo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/src/main/java/contest/collectingbox/module/publicdata/presentation/PublicDataApiController.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/presentation/PublicDataApiController.java
@@ -7,19 +7,10 @@ import contest.collectingbox.module.publicdata.dto.LoadPublicDataRequest;
 import contest.collectingbox.module.publicdata.dto.SavePublicDataApiInfoRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Slf4j
@@ -27,12 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PublicDataApiController {
 
-    private static final String TOTAL_COUNT_KEY = "totalCount";
-
     private final PublicDataService publicDataService;
-
-    @Value("${public-data.api.key}")
-    private String apiKey;
 
     @PostMapping("/public-data/info")
     public ApiResponse<Integer> savePublicDataApiInfo(@RequestBody List<SavePublicDataApiInfoRequest> requests) {
@@ -42,21 +28,7 @@ public class PublicDataApiController {
 
     @PostMapping("/public-data/load")
     public ApiResponse<Long> loadPublicData(@RequestBody List<LoadPublicDataRequest> requests) {
-        long loadedDataCount = 0;
-        for (LoadPublicDataRequest request : requests) {
-            try {
-                log.info("======= {} - {} =======%n", request.getSigungu(), request.getTag().getLabel());
-                int totalCount = getTotalCountOfPublicData(request);
-                loadedDataCount += publicDataService.loadPublicData(callPublicDataApi(request, totalCount),
-                        request.getSigungu(),
-                        request.getTag());
-
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return ApiResponse.ok(loadedDataCount);
+        return ApiResponse.ok(publicDataService.loadPublicData(requests));
     }
 
     @PostMapping("/public-data/csv")
@@ -66,19 +38,5 @@ public class PublicDataApiController {
             loadedDataCount += publicDataService.loadCsvPublicData(request);
         }
         return ApiResponse.ok(loadedDataCount);
-    }
-
-    private JSONObject callPublicDataApi(LoadPublicDataRequest request, int perPage) throws IOException {
-        URL url = new URL(request.getUrlWithPerPage(apiKey, perPage));
-        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-        urlConnection.setRequestMethod(HttpMethod.GET.name());
-        urlConnection.setRequestProperty("Content-type", "application/json");
-
-        BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
-        return new JSONObject(br.readLine());
-    }
-
-    private int getTotalCountOfPublicData(LoadPublicDataRequest request) throws IOException {
-        return Integer.parseInt(callPublicDataApi(request, 1).get(TOTAL_COUNT_KEY).toString());
     }
 }

--- a/src/main/java/contest/collectingbox/module/publicdata/presentation/PublicDataApiController.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/presentation/PublicDataApiController.java
@@ -1,6 +1,10 @@
-package contest.collectingbox.module.publicdata;
+package contest.collectingbox.module.publicdata.presentation;
 
 import contest.collectingbox.global.common.ApiResponse;
+import contest.collectingbox.module.publicdata.application.PublicDataService;
+import contest.collectingbox.module.publicdata.dto.LoadCsvPublicDataRequest;
+import contest.collectingbox.module.publicdata.dto.LoadPublicDataRequest;
+import contest.collectingbox.module.publicdata.dto.SavePublicDataApiInfoRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
@@ -41,7 +45,7 @@ public class PublicDataApiController {
         long loadedDataCount = 0;
         for (LoadPublicDataRequest request : requests) {
             try {
-                System.out.printf("======= %s - %s =======%n", request.getSigungu(), request.getTag().getLabel());
+                log.info("======= {} - {} =======%n", request.getSigungu(), request.getTag().getLabel());
                 int totalCount = getTotalCountOfPublicData(request);
                 loadedDataCount += publicDataService.loadPublicData(callPublicDataApi(request, totalCount),
                         request.getSigungu(),


### PR DESCRIPTION
## 💡 작업 내용
- [x] 패키지 구조 개선
- [x] 코드 구조 개선
- [x] RestTemplate 라이브러리 사용

## 💡 자세한 설명
유지보수가 쉬운 코드로 리팩토링하기 위해, 기존 공공데이터 포털 API 호출 로직을 RestTemplate 라이브러리를 사용하여 호출하도록 개선했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #121 
