### PR TITLE
[공공데이터 저장 기능] 카카오 API 호출하는 코드 구조 개선

### DIFF
--- a/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
+++ b/src/main/java/contest/collectingbox/global/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     NOT_FOUND_TAG(NOT_FOUND, "해당 이름과 일치하는 수거함 태그가 없습니다."),
 
     // 500
-    UNEXPECTED_ERROR_EXTERNAL_API(INTERNAL_SERVER_ERROR, "외부 API 호출 시 알 수 없는 예외가 발생했습니다.");
+    UNEXPECTED_ERROR_EXTERNAL_API(INTERNAL_SERVER_ERROR, "외부 API 호출 시 알 수 없는 예외가 발생했습니다."),
+    ERROR_PARSING_JSON_KAKAO_API(INTERNAL_SERVER_ERROR, "Error parsing JSON from Kakao API");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/AddressInfoMapper.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/AddressInfoMapper.java
@@ -6,11 +6,12 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.json.JSONObject;
 
-import static contest.collectingbox.module.publicdata.dto.AddressInfoDto.*;
+import static contest.collectingbox.module.publicdata.dto.AddressInfoDto.AddressInfoDtoBuilder;
+import static contest.collectingbox.module.publicdata.dto.AddressInfoDto.builder;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AddressInfoMapper {
-    public static AddressInfoDto jsonObjectToAddressInfoDto(JSONObject document, Tag tag) {
+    public static AddressInfoDto fromJsonObjectAndTag(JSONObject document, Tag tag) {
         JSONObject address = document.getJSONObject("address");
         JSONObject roadAddress = document.getJSONObject("road_address");
 

--- a/src/main/java/contest/collectingbox/module/publicdata/domain/KakaoApiManager.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/domain/KakaoApiManager.java
@@ -1,5 +1,6 @@
 package contest.collectingbox.module.publicdata.domain;
 
+import contest.collectingbox.global.exception.CollectingBoxException;
 import contest.collectingbox.module.collectingbox.domain.Tag;
 import contest.collectingbox.module.publicdata.dto.AddressInfoDto;
 import lombok.RequiredArgsConstructor;
@@ -8,19 +9,25 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 
+import static contest.collectingbox.global.exception.ErrorCode.ERROR_PARSING_JSON_KAKAO_API;
+import static contest.collectingbox.global.exception.ErrorCode.UNEXPECTED_ERROR_EXTERNAL_API;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class KakaoApiManager {
+
     private static final String API_URL = "https://dapi.kakao.com/v2/local/search/address.json";
 
     @Value("${kakao.api.key}")
@@ -31,8 +38,8 @@ public class KakaoApiManager {
             ResponseEntity<String> response = callKakaoAPI(query);
 
             // 카카오 API 예외 처리
-            if (response.getStatusCode() != HttpStatus.OK) {
-                throw new RuntimeException("Kakao API failed status = " + response.getStatusCode());
+            if (response.getStatusCode().isError()) {
+                throw new CollectingBoxException(UNEXPECTED_ERROR_EXTERNAL_API);
             }
 
             // 주소 정보 추출
@@ -49,16 +56,16 @@ public class KakaoApiManager {
                 return null;
             }
 
-            return AddressInfoMapper.jsonObjectToAddressInfoDto(document, tag);
+            return AddressInfoMapper.fromJsonObjectAndTag(document, tag);
         } catch (JSONException e) {
-            throw new RuntimeException("Error parsing JSON from Kakao API", e);
+            throw new CollectingBoxException(ERROR_PARSING_JSON_KAKAO_API);
         }
     }
 
     private ResponseEntity<String> callKakaoAPI(String query) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set("Authorization", "KakaoAK " + apiKey);
+        httpHeaders.set("Authorization", "KakaoAK %s".formatted(apiKey));
         HttpEntity<Object> httpEntity = new HttpEntity<>(httpHeaders);
         URI targetUrl = UriComponentsBuilder.fromUriString(API_URL).queryParam("query", query)
                 .build().encode(UTF_8).toUri();

--- a/src/main/java/contest/collectingbox/module/publicdata/dto/LoadPublicDataRequest.java
+++ b/src/main/java/contest/collectingbox/module/publicdata/dto/LoadPublicDataRequest.java
@@ -9,8 +9,4 @@ public class LoadPublicDataRequest {
     private String sigungu;
     private Tag tag;
     private String callAddress;
-
-    public String getUrlWithPerPage(String apiKey, int perPage) {
-        return String.format("https://api.odcloud.kr/api%s?serviceKey=%s&perPage=%d", callAddress, apiKey, perPage);
-    }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 카카오 API 호출하는 코드 구조 개선

## 💡 자세한 설명
공공데이터 저장 기능에서, 카카오 API를 호출하여 DTO를 매핑하는 코드 구조를 개선했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #130 
